### PR TITLE
fix: use correct CSV flag (Index 9) for merging and remove parenthese…

### DIFF
--- a/worker/crawler/src/file/parse/csv.rs
+++ b/worker/crawler/src/file/parse/csv.rs
@@ -31,6 +31,21 @@ fn replace_japanese_to_alphanumeric_with_cache(s: &str, cache: &HashMap<char, &s
         .collect()
 }
 
+fn remove_parentheses(s: &str) -> String {
+    let mut result = String::new();
+    let mut in_parens = false;
+    for c in s.chars() {
+        if c == '(' {
+            in_parens = true;
+        } else if c == ')' {
+            in_parens = false;
+        } else if !in_parens {
+            result.push(c);
+        }
+    }
+    result
+}
+
 //  Format CSV file records
 fn format_csv_record_with_cache(
     record: VecDeque<String>,
@@ -51,13 +66,30 @@ fn format_csv_record_with_cache(
         || "".to_string(),
         |s| replace_japanese_to_alphanumeric_with_cache(s, replace_cache),
     );
-    let town = record
+    let raw_town = record
         .get(8)
         .map(|s| replace_japanese_to_alphanumeric_with_cache(s, replace_cache))
         .unwrap_or_default();
 
-    // Column 12 indicates if the address is split across multiple lines (1 = split, 0 = not split)
-    let is_split = record.get(12).map(|s| s == "1").unwrap_or(false);
+    // Remove parentheses content (e.g., "銀座(1丁目)" -> "銀座")
+    let town = remove_parentheses(&raw_town);
+
+    // Column 9 indicates if one zip code represents multiple town areas (1 = yes, 0 = no)
+    // If 0, it means the zip code corresponds to a single town area (which might be split across lines)
+    // If 1, it means the zip code covers multiple distinct towns, so we should NOT merge them.
+    let multi_town_in_zip = record
+        .get(8) // Index 8 is actually town name, wait. CSV index is 0-based.
+        // 0: JIS code, 1: old zip, 2: zip, 3: pref kana, 4: city kana, 5: town kana
+        // 6: pref, 7: city, 8: town
+        // 9: multi-town flag (1=yes, 0=no)
+        // 10: koaza flag
+        // 11: chome flag
+        // 12: multi-zip for one town flag
+        // 13: update status
+        // 14: update reason
+        .and_then(|_| record.get(9)) // Access Index 9 correctly
+        .map(|s| s == "1")
+        .unwrap_or(false);
 
     (
         PostalCode {
@@ -72,7 +104,7 @@ fn format_csv_record_with_cache(
                 town
             },
         },
-        is_split,
+        multi_town_in_zip,
     )
 }
 
@@ -113,35 +145,37 @@ pub async fn csv_stream_format(
     let mut records_vec: Vec<PostalCode> = Vec::new();
     let mut records = csv_reader.into_records();
     let mut prev_record: Option<PostalCode> = None;
-    let mut prev_was_split = false;
+    let mut prev_multi_town_in_zip = false;
 
     while let Some(result) = records.next().await {
         match result {
             Ok(record) => {
                 let deque: VecDeque<String> = record.iter().map(|s| s.to_string()).collect();
-                let (current, is_split) =
+                let (current, multi_town_in_zip) =
                     format_csv_record_with_cache(deque, &pref_cache, &replace_cache);
 
                 if let Some(ref mut prev) = prev_record {
-                    // Merge ONLY if both previous and current records are flagged as split
-                    // AND they share the same key (Zip + City)
-                    if prev_was_split
-                        && is_split
-                        && prev.zip_code == current.zip_code
+                    // Merge logic:
+                    // 1. Same Zip Code and City ID
+                    // 2. AND 'multi_town_in_zip' flag is 0 for BOTH records (Index 9)
+                    //    If flag is 1, it means multiple distinct towns share the zip, so NO merge.
+                    //    If flag is 0, it implies a single town entity, so split lines should be merged.
+                    if prev.zip_code == current.zip_code
                         && prev.city_id == current.city_id
+                        && !prev_multi_town_in_zip
+                        && !multi_town_in_zip
                     {
                         prev.town.push_str(&current.town);
-                        // Continue to next record, keeping 'prev' as the accumulator
-                        // 'prev_was_split' remains true (or we could update it to is_split, which is true)
+                        // Continue to next record, keeping 'prev' as accumulator
                         continue;
                     } else {
-                        // Not a continuation, push the previous record
+                        // Different record or distinct towns, push previous
                         records_vec.push(prev.clone());
                     }
                 }
-                // Update prev_record to current
+                // Update prev_record
                 prev_record = Some(current);
-                prev_was_split = is_split;
+                prev_multi_town_in_zip = multi_town_in_zip;
             }
             Err(e) => eprintln!("Error processing record: {:?}", e),
         }


### PR DESCRIPTION
マージ条件の修正 (Index 12 → Index 9)にバグ有り。
ndex 12（複数郵便番号フラグ）ではなく
、Index 9（複数町域フラグ） を見るように変更。

multi_town_in_zip (Index 9) が 0 の場合のみ、
「一つの町域が分割されている」と判断して結合します。
これで「長い住所」は結合され、「別の町」は分離されます。

括弧の中身除去
remove_parentheses 関数を実装しました
（regex 依存なしで高速化）。
「銀座(1丁目)」→「銀座」のように、括弧とその中身をきれいに削除してから登録します。
これで検索・補完のUXが劇的に向上します。