### PR TITLE
ci: add Helm lint/template checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,3 +128,24 @@ jobs:
       - name: Build Launcher
         working-directory: launcher
         run: go build -v ./...
+
+  helm:
+    name: Helm Lint & Template
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.3
+
+      - name: Helm lint
+        run: helm lint deploy/helm/postal-converter-ja
+
+      - name: Helm template
+        run: |
+          helm template postal-converter-ja deploy/helm/postal-converter-ja \
+            --namespace postal-converter-ja \
+            > /tmp/postal-converter-ja-rendered.yaml
+          test -s /tmp/postal-converter-ja-rendered.yaml

--- a/.github/workflows/terraform-multiplatform.yml
+++ b/.github/workflows/terraform-multiplatform.yml
@@ -90,19 +90,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Guard AWS secret
-        run: |
-          if [ -z "${AWS_ROLE_TO_ASSUME}" ]; then
-            echo "::error::AWS_ROLE_TO_ASSUME is not configured."
-            exit 1
-          fi
-
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.11.1
 
+      - name: Plan mode
+        run: |
+          if [ -z "${AWS_ROLE_TO_ASSUME}" ]; then
+            echo "Running offline plan mode (no AWS OIDC secret configured)."
+          else
+            echo "Running OIDC-backed plan mode."
+          fi
+
       - name: Configure AWS credentials (OIDC)
+        if: env.AWS_ROLE_TO_ASSUME != ''
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/terraform-multiplatform.yml
+++ b/.github/workflows/terraform-multiplatform.yml
@@ -1,4 +1,4 @@
-name: Terraform Multi-Platform Skeleton
+name: Terraform AWS Baseline
 
 on:
   pull_request:
@@ -52,19 +52,13 @@ jobs:
       - name: Check formatting
         run: terraform fmt -check -recursive infra/terraform
 
-  terraform-validate:
-    name: Terraform Validate (${{ matrix.platform }})
+  terraform-validate-aws:
+    name: Terraform Validate (aws)
     runs-on: ubuntu-latest
     needs: terraform-fmt
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [aws, gcp, azure]
-
     defaults:
       run:
-        working-directory: infra/terraform/platforms/${{ matrix.platform }}
-
+        working-directory: infra/terraform/platforms/aws
     steps:
       - uses: actions/checkout@v4
 
@@ -79,33 +73,29 @@ jobs:
       - name: Terraform validate
         run: terraform validate
 
-  terraform-plan:
-    name: Terraform Plan (${{ matrix.platform }})
+  terraform-plan-aws:
+    name: Terraform Plan (aws)
     runs-on: ubuntu-latest
-    needs: terraform-validate
+    needs: terraform-validate-aws
     if: github.event_name == 'workflow_dispatch' && inputs.action == 'plan'
     permissions:
       contents: read
       id-token: write
     env:
       AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [aws, gcp, azure]
-
+      TARGET_ENV: ${{ inputs.environment }}
     defaults:
       run:
-        working-directory: infra/terraform/platforms/${{ matrix.platform }}
-
+        working-directory: infra/terraform/platforms/aws
     steps:
       - uses: actions/checkout@v4
+
+      - name: Guard AWS secret
+        run: |
+          if [ -z "${AWS_ROLE_TO_ASSUME}" ]; then
+            echo "::error::AWS_ROLE_TO_ASSUME is not configured."
+            exit 1
+          fi
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -113,76 +103,21 @@ jobs:
           terraform_version: 1.11.1
 
       - name: Configure AWS credentials (OIDC)
-        if: matrix.platform == 'aws' && env.AWS_ROLE_TO_ASSUME != ''
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ vars.AWS_REGION || 'ap-northeast-1' }}
-          role-session-name: gha-terraform-${{ inputs.environment }}
-
-      - name: Warn when AWS OIDC secret is missing
-        if: matrix.platform == 'aws' && env.AWS_ROLE_TO_ASSUME == ''
-        run: |
-          echo "::warning::AWS_ROLE_TO_ASSUME is not configured. AWS authenticated plan is skipped."
-          exit 0
-
-      #Node: Add per-cloud OIDC auth here before enabling real deploy/apply.
-      - name: Configure GCP credentials (OIDC)
-        if: matrix.platform == 'gcp' && env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != ''
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
-          project_id: ${{ env.GCP_PROJECT_ID }}
-          create_credentials_file: true
-          export_environment_variables: true
-
-      - name: Warn when GCP OIDC secrets are missing
-        if: matrix.platform == 'gcp' && (env.GCP_WORKLOAD_IDENTITY_PROVIDER == '' || env.GCP_SERVICE_ACCOUNT == '')
-        run: |
-          echo "::warning::GCP_WORKLOAD_IDENTITY_PROVIDER / GCP_SERVICE_ACCOUNT is not configured. GCP authenticated plan is skipped."
-          exit 0
-
-      - name: Configure Azure credentials (OIDC)
-        if: matrix.platform == 'azure' && env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != ''
-        uses: azure/login@v2
-        with:
-          client-id: ${{ env.AZURE_CLIENT_ID }}
-          tenant-id: ${{ env.AZURE_TENANT_ID }}
-          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Warn when Azure OIDC secrets are missing
-        if: matrix.platform == 'azure' && (env.AZURE_CLIENT_ID == '' || env.AZURE_TENANT_ID == '' || env.AZURE_SUBSCRIPTION_ID == '')
-        run: |
-          echo "::warning::AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_SUBSCRIPTION_ID is not configured. Azure authenticated plan is skipped."
-          exit 0
+          role-session-name: gha-terraform-plan-${{ inputs.environment }}
 
       - name: Terraform init (no backend)
-        if: |
-          (matrix.platform == 'aws' && env.AWS_ROLE_TO_ASSUME != '') ||
-          (matrix.platform == 'gcp' && env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '') ||
-          (matrix.platform == 'azure' && env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '')
         run: terraform init -backend=false
 
-      - name: Terraform plan (skeleton)
-        if: |
-          (matrix.platform == 'aws' && env.AWS_ROLE_TO_ASSUME != '') ||
-          (matrix.platform == 'gcp' && env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && env.GCP_SERVICE_ACCOUNT != '') ||
-          (matrix.platform == 'azure' && env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '')
-        env:
-          TARGET_ENV: ${{ inputs.environment }}
+      - name: Terraform plan (aws baseline)
         run: |
-          TFVARS="../../environments/${TARGET_ENV}/${{ matrix.platform }}.tfvars"
+          TFVARS="../../environments/${TARGET_ENV}/aws.tfvars"
           if [ ! -f "${TFVARS}" ]; then
-            echo "::warning::tfvars not found: ${TFVARS}. skip plan."
-            echo "#Node: create ${TARGET_ENV}/${{ matrix.platform }}.tfvars before enabling this plan."
-            exit 0
-          fi
-
-          if [ "${{ matrix.platform }}" = "gcp" ] && grep -q 'replace-me' "${TFVARS}"; then
-            echo "::warning::gcp.tfvars has placeholder project_id. skip plan."
-            echo "#Node: set real project_id in ${TFVARS}."
-            exit 0
+            echo "::error::tfvars not found: ${TFVARS}"
+            exit 1
           fi
 
           terraform plan \
@@ -193,17 +128,16 @@ jobs:
             -out=tfplan
 
       - name: Upload plan artifact
-        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: tfplan-${{ matrix.platform }}-${{ inputs.environment }}
-          path: infra/terraform/platforms/${{ matrix.platform }}/tfplan
-          if-no-files-found: ignore
+          name: tfplan-aws-${{ inputs.environment }}
+          path: infra/terraform/platforms/aws/tfplan
+          if-no-files-found: error
 
   terraform-apply-aws:
     name: Terraform Apply (aws)
     runs-on: ubuntu-latest
-    needs: terraform-validate
+    needs: terraform-validate-aws
     if: github.event_name == 'workflow_dispatch' && inputs.action == 'apply'
     permissions:
       contents: read
@@ -246,7 +180,7 @@ jobs:
       - name: Terraform init (no backend)
         run: terraform init -backend=false
 
-      - name: Terraform apply (aws skeleton)
+      - name: Terraform apply (aws baseline)
         run: |
           TFVARS="../../environments/${TARGET_ENV}/aws.tfvars"
           if [ ! -f "${TFVARS}" ]; then

--- a/.github/workflows/terraform-multiplatform.yml
+++ b/.github/workflows/terraform-multiplatform.yml
@@ -28,8 +28,14 @@ on:
           - validate
           - plan
           - apply
+          - destroy
       confirm_apply:
         description: "Type APPLY_AWS to run AWS apply"
+        required: false
+        default: ""
+        type: string
+      confirm_destroy:
+        description: "Type DESTROY_AWS to run AWS destroy"
         required: false
         default: ""
         type: string
@@ -89,13 +95,6 @@ jobs:
         working-directory: infra/terraform/platforms/aws
     steps:
       - uses: actions/checkout@v4
-
-      - name: Guard AWS secret
-        run: |
-          if [ -z "${AWS_ROLE_TO_ASSUME}" ]; then
-            echo "::error::AWS_ROLE_TO_ASSUME is not configured."
-            exit 1
-          fi
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -197,3 +196,58 @@ jobs:
             exit 1
           fi
           terraform apply -auto-approve -input=false -lock=false -var-file="${TFVARS}"
+
+  terraform-destroy-aws:
+    name: Terraform Destroy (aws)
+    runs-on: ubuntu-latest
+    needs: terraform-validate-aws
+    if: github.event_name == 'workflow_dispatch' && inputs.action == 'destroy'
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+      TARGET_ENV: ${{ inputs.environment }}
+    defaults:
+      run:
+        working-directory: infra/terraform/platforms/aws
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Guard confirm token
+        run: |
+          if [ "${{ inputs.confirm_destroy }}" != "DESTROY_AWS" ]; then
+            echo "::error::confirm_destroy must be DESTROY_AWS for destroy action."
+            exit 1
+          fi
+
+      - name: Guard AWS secret
+        run: |
+          if [ -z "${AWS_ROLE_TO_ASSUME}" ]; then
+            echo "::error::AWS_ROLE_TO_ASSUME is not configured."
+            exit 1
+          fi
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.11.1
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.AWS_REGION || 'ap-northeast-1' }}
+          role-session-name: gha-terraform-destroy-${{ inputs.environment }}
+
+      - name: Terraform init (no backend)
+        run: terraform init -backend=false
+
+      - name: Terraform destroy (aws baseline)
+        run: |
+          TFVARS="../../environments/${TARGET_ENV}/aws.tfvars"
+          if [ ! -f "${TFVARS}" ]; then
+            echo "::error::tfvars not found: ${TFVARS}"
+            exit 1
+          fi
+          terraform destroy -auto-approve -refresh=false -input=false -lock=false -var-file="${TFVARS}"

--- a/README.md
+++ b/README.md
@@ -336,6 +336,12 @@ SSOヘッダ認証（`AUTH_MODE=sso_header`）:
 `terraform` がローカルシェルで見えない場合は、Nix dev shell 経由で実行してください（Nix では OpenTofu 互換の `terraform` コマンドを提供）。  
 Homebrew 経由では `terraform` が 1.5.7 固定になることがあるため、バージョン差異を避ける目的でも Nix を推奨します。
 
+Terraform バージョン方針（v0.8）:
+
+- 最小要件: `>= 1.6.0`（`infra/terraform/platforms/aws/main.tf`）
+- CI 固定: `1.11.1`（`.github/workflows/terraform-multiplatform.yml`）
+- ローカル推奨: `1.11+`（この端末の確認値: `1.14.5`）
+
 ```bash
 nix develop --command terraform fmt -check -recursive infra/terraform
 nix develop --command terraform -chdir=infra/terraform/platforms/aws validate

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 郵便番号自動最新化システム (Postal Converter JA)
 
-![Version](https://img.shields.io/badge/version-0.7.0-blue.svg)
+![Version](https://img.shields.io/badge/version-0.8.0-blue.svg)
 ![Status](https://img.shields.io/badge/status-beta-orange.svg)
 
 English README: [ENGLISH_README.md](./docs/ENGLISH_README.md)
@@ -333,6 +333,7 @@ SSOヘッダ認証（`AUTH_MODE=sso_header`）:
 👉 **v0.8 rollback 証跡:** [TERRAFORM_ROLLBACK_REHEARSAL_EVIDENCE.md](./docs/TERRAFORM_ROLLBACK_REHEARSAL_EVIDENCE.md)
 👉 **GitHub OIDC 設定スクリプト:** `./scripts/setup_github_oidc_vars.sh`
 👉 **Terraform workflow 実行スクリプト:** `./scripts/run_terraform_workflow.sh`
+👉 **Terraform rollback 実行（CI）:** `./scripts/run_terraform_workflow.sh --action destroy --environment dev --confirm-destroy DESTROY_AWS --ref feature/v0.8.0`
 👉 **Terraform ローカル確認（Nix dev shell）:** `nix develop --command terraform version`
 
 `terraform` がローカルシェルで見えない場合は、Nix dev shell 経由で実行してください（Nix では OpenTofu 互換の `terraform` コマンドを提供）。  
@@ -378,27 +379,27 @@ CI でも同等チェック（fmt/validate）を実行します。
 ## ロードマップ (TODO)
 
 詳細な実行計画（優先度・日付入り）は `docs/SALES_READINESS_PLAN_2026Q2.md` を参照してください。  
-v0.7.0 以降の実行順序は `docs/V0_7_TO_V1_EXECUTION_PLAN.md` を参照してください。
+v0.8.0 以降の実行順序は `docs/V0_7_TO_V1_EXECUTION_PLAN.md` を参照してください。
 
 - [x] **CI/CD パイプラインの構築**: GitHub Actions による自動テスト・ビルド
 - [x] **ランチャーの UX 改善**: 実行順序の制御と視覚的フィードバック
 - [x] **環境構築の自動化 (v0.6)**: `scripts/setup_nix_docker.sh` + `scripts/onboard.sh` で導入を標準化
-- [ ] **デプロイ基盤 (v0.8)**: GitHub Actions + Terraform の AWS 先行運用を確立（その後マルチクラウド展開）
+- [x] **デプロイ基盤 (v0.8)**: GitHub Actions + Terraform の AWS 先行運用を確立（その後マルチクラウド展開）
 - [x] **MySQL/PostgreSQL の自動テスト**: 両 DB でのインテグレーションテスト追加
 - [x] **Docker イメージの軽量化**: マルチステージビルドの最適化（API/Crawler）
 - [ ] **Kubernetes 連携**: コンテナ連携・オーケストレーション対応（Helm/Kustomize 含む）
 - [x] **API ドキュメントの拡充**: Swagger/OpenAPI による仕様書生成
 
-### v0.7.0 フォーカス（導入加速）
+### v0.8.0 フォーカス（デプロイ基盤）
 
-- [x] **導入SDKサンプル拡張**: EC / 会員登録 / コールセンター の3ユースケース
-- [x] **導入テンプレート整備**: 受託向け導入チェックリストを追加（`docs/CONTRACTOR_ONBOARDING_CHECKLIST.md`）
-- [x] **オンボーディング最終UX**: 同一ホスト端末での疎通証跡を取得（`docs/ONBOARDING_REHEARSAL_EVIDENCE.md`）
-- [x] **SQLite配布の運用基準化**: 月次運用チェックリストを追加（`docs/SQLITE_MONTHLY_OPERATION_CHECKLIST.md`）
+- [x] **AWS先行IaC運用**: GitHub Actions + Terraform の `validate/plan/apply` を `dev` で実行可能化
+- [x] **環境分離**: `dev/stg/prod` の `aws.tfvars` を追加
+- [x] **オフライン検証経路**: AWSシークレット未設定でも `plan` を実行できる導線を整備
+- [x] **ロールバック運用**: `destroy` 手順を runbook 化し、実行証跡を追加
 
 ## バージョン
 
-**v0.7.0 (Beta)** - Sales-ready onboarding kit
+**v0.8.0 (Beta)** - Deployment baseline with AWS-first Terraform workflow
 
 ## 貢献について (Contributing)
 

--- a/README.md
+++ b/README.md
@@ -331,6 +331,17 @@ SSOヘッダ認証（`AUTH_MODE=sso_header`）:
 👉 **デプロイ骨格（GitHub Actions + Terraform）はこちら:** [DEPLOY.md](./docs/DEPLOY.md)
 👉 **GitHub OIDC 設定スクリプト:** `./scripts/setup_github_oidc_vars.sh`
 👉 **Terraform workflow 実行スクリプト:** `./scripts/run_terraform_workflow.sh`
+👉 **Terraform ローカル確認（Nix dev shell）:** `nix develop --command terraform version`
+
+`terraform` がローカルシェルで見えない場合は、Nix dev shell 経由で実行してください（Nix では OpenTofu 互換の `terraform` コマンドを提供）。  
+Homebrew 経由では `terraform` が 1.5.7 固定になることがあるため、バージョン差異を避ける目的でも Nix を推奨します。
+
+```bash
+nix develop --command terraform fmt -check -recursive infra/terraform
+nix develop --command terraform -chdir=infra/terraform/platforms/aws validate
+```
+
+CI でも同等チェック（fmt/validate）を実行します。
 
 👉 **SQLite read-only PoC についてはこちら:** [SQLITE_READONLY_POC.md](./docs/SQLITE_READONLY_POC.md)
 

--- a/README.md
+++ b/README.md
@@ -356,7 +356,6 @@ CI でも同等チェック（fmt/validate）を実行します。
 
 👉 **SQLite 配布ワークフロー（GitHub Actions 手動実行）:** `.github/workflows/sqlite-release.yml`
 
-👉 **販売準備ロードマップ（2026年4月目標）はこちら:** [SALES_READINESS_PLAN_2026Q2.md](./docs/SALES_READINESS_PLAN_2026Q2.md)
 
 ## ライセンスと商用利用について
 
@@ -373,29 +372,27 @@ CI でも同等チェック（fmt/validate）を実行します。
 
 このモデルにより、オープンソースとしての発展と、持続可能な開発体制の両立を目指しています。
 
-> [!NOTE]
-> 個人受託を先行しやすくするための「条件付きフリーライセンス案」は、`docs/SALES_READINESS_PLAN_2026Q2.md` を参照してください。
-
 ## ロードマップ (TODO)
 
-詳細な実行計画（優先度・日付入り）は `docs/SALES_READINESS_PLAN_2026Q2.md` を参照してください。  
-v0.8.0 以降の実行順序は `docs/V0_7_TO_V1_EXECUTION_PLAN.md` を参照してください。
+実行順序とマイルストーンは `docs/V0_7_TO_V1_EXECUTION_PLAN.md` を参照してください。
 
 - [x] **CI/CD パイプラインの構築**: GitHub Actions による自動テスト・ビルド
 - [x] **ランチャーの UX 改善**: 実行順序の制御と視覚的フィードバック
 - [x] **環境構築の自動化 (v0.6)**: `scripts/setup_nix_docker.sh` + `scripts/onboard.sh` で導入を標準化
-- [x] **デプロイ基盤 (v0.8)**: GitHub Actions + Terraform の AWS 先行運用を確立（その後マルチクラウド展開）
+- [ ] **マルチプラットフォーム デプロイ基盤**: GitHub Actions + Terraform による環境展開（クラウド別ターゲット対応）
 - [x] **MySQL/PostgreSQL の自動テスト**: 両 DB でのインテグレーションテスト追加
 - [x] **Docker イメージの軽量化**: マルチステージビルドの最適化（API/Crawler）
 - [ ] **Kubernetes 連携**: コンテナ連携・オーケストレーション対応（Helm/Kustomize 含む）
 - [x] **API ドキュメントの拡充**: Swagger/OpenAPI による仕様書生成
 
-### v0.8.0 フォーカス（デプロイ基盤）
+### v0.8.1 フォーカス（デプロイ基盤の仕上げ）
 
-- [x] **AWS先行IaC運用**: GitHub Actions + Terraform の `validate/plan/apply` を `dev` で実行可能化
+- [x] **AWS先行IaC運用**: GitHub Actions + Terraform の `validate/plan/apply/destroy` を `dev` で実行可能化
 - [x] **環境分離**: `dev/stg/prod` の `aws.tfvars` を追加
 - [x] **オフライン検証経路**: AWSシークレット未設定でも `plan` を実行できる導線を整備
 - [x] **ロールバック運用**: `destroy` 手順を runbook 化し、実行証跡を追加
+- [ ] **マルチクラウド再拡張**: GCP/Azure ターゲットの再導入
+- [ ] **Kubernetes最小構成**: Helm/Kustomize 雛形の追加
 
 ## バージョン
 

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ SSOヘッダ認証（`AUTH_MODE=sso_header`）:
 
 👉 **デプロイ骨格（GitHub Actions + Terraform）はこちら:** [DEPLOY.md](./docs/DEPLOY.md)
 👉 **v0.8 offline plan 証跡:** [TERRAFORM_OFFLINE_PLAN_EVIDENCE.md](./docs/TERRAFORM_OFFLINE_PLAN_EVIDENCE.md)
+👉 **v0.8 rollback 証跡:** [TERRAFORM_ROLLBACK_REHEARSAL_EVIDENCE.md](./docs/TERRAFORM_ROLLBACK_REHEARSAL_EVIDENCE.md)
 👉 **GitHub OIDC 設定スクリプト:** `./scripts/setup_github_oidc_vars.sh`
 👉 **Terraform workflow 実行スクリプト:** `./scripts/run_terraform_workflow.sh`
 👉 **Terraform ローカル確認（Nix dev shell）:** `nix develop --command terraform version`

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ SSOヘッダ認証（`AUTH_MODE=sso_header`）:
 
 👉 **デプロイ骨格（GitHub Actions + Terraform）はこちら:** [DEPLOY.md](./docs/DEPLOY.md)
 👉 **Kubernetes 導入ガイド（v0.8.2）:** [KUBERNETES_DEPLOYMENT.md](./docs/KUBERNETES_DEPLOYMENT.md)
+👉 **Kubernetes 導入設計図（既存運用向け）:** [K8S_ADOPTION_BLUEPRINT.md](./docs/K8S_ADOPTION_BLUEPRINT.md)
 👉 **Kubernetes 最小雛形:** `deploy/helm/postal-converter-ja` (Helm / デフォルト), `deploy/k8s/base` (Kustomize), `deploy/argocd` (ArgoCD route)
 👉 **v0.8 offline plan 証跡:** [TERRAFORM_OFFLINE_PLAN_EVIDENCE.md](./docs/TERRAFORM_OFFLINE_PLAN_EVIDENCE.md)
 👉 **v0.8 rollback 証跡:** [TERRAFORM_ROLLBACK_REHEARSAL_EVIDENCE.md](./docs/TERRAFORM_ROLLBACK_REHEARSAL_EVIDENCE.md)

--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ SSOヘッダ認証（`AUTH_MODE=sso_header`）:
 👉 **CI/CD 設計についてはこちら:** [CI_DESIGN.md](./docs/CI_DESIGN.md)
 
 👉 **デプロイ骨格（GitHub Actions + Terraform）はこちら:** [DEPLOY.md](./docs/DEPLOY.md)
+👉 **v0.8 offline plan 証跡:** [TERRAFORM_OFFLINE_PLAN_EVIDENCE.md](./docs/TERRAFORM_OFFLINE_PLAN_EVIDENCE.md)
 👉 **GitHub OIDC 設定スクリプト:** `./scripts/setup_github_oidc_vars.sh`
 👉 **Terraform workflow 実行スクリプト:** `./scripts/run_terraform_workflow.sh`
 👉 **Terraform ローカル確認（Nix dev shell）:** `nix develop --command terraform version`

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ v0.7.0 以降の実行順序は `docs/V0_7_TO_V1_EXECUTION_PLAN.md` を参照し
 - [x] **CI/CD パイプラインの構築**: GitHub Actions による自動テスト・ビルド
 - [x] **ランチャーの UX 改善**: 実行順序の制御と視覚的フィードバック
 - [x] **環境構築の自動化 (v0.6)**: `scripts/setup_nix_docker.sh` + `scripts/onboard.sh` で導入を標準化
-- [ ] **マルチプラットフォーム デプロイ基盤**: GitHub Actions + Terraform による環境展開（クラウド別ターゲット対応）
+- [ ] **デプロイ基盤 (v0.8)**: GitHub Actions + Terraform の AWS 先行運用を確立（その後マルチクラウド展開）
 - [x] **MySQL/PostgreSQL の自動テスト**: 両 DB でのインテグレーションテスト追加
 - [x] **Docker イメージの軽量化**: マルチステージビルドの最適化（API/Crawler）
 - [ ] **Kubernetes 連携**: コンテナ連携・オーケストレーション対応（Helm/Kustomize 含む）

--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ SSOヘッダ認証（`AUTH_MODE=sso_header`）:
 👉 **CI/CD 設計についてはこちら:** [CI_DESIGN.md](./docs/CI_DESIGN.md)
 
 👉 **デプロイ骨格（GitHub Actions + Terraform）はこちら:** [DEPLOY.md](./docs/DEPLOY.md)
+👉 **Kubernetes 導入ガイド（v0.8.2）:** [KUBERNETES_DEPLOYMENT.md](./docs/KUBERNETES_DEPLOYMENT.md)
+👉 **Kubernetes 最小雛形:** `deploy/helm/postal-converter-ja` (Helm / デフォルト), `deploy/k8s/base` (Kustomize), `deploy/argocd` (ArgoCD route)
 👉 **v0.8 offline plan 証跡:** [TERRAFORM_OFFLINE_PLAN_EVIDENCE.md](./docs/TERRAFORM_OFFLINE_PLAN_EVIDENCE.md)
 👉 **v0.8 rollback 証跡:** [TERRAFORM_ROLLBACK_REHEARSAL_EVIDENCE.md](./docs/TERRAFORM_ROLLBACK_REHEARSAL_EVIDENCE.md)
 👉 **GitHub OIDC 設定スクリプト:** `./scripts/setup_github_oidc_vars.sh`
@@ -382,17 +384,17 @@ CI でも同等チェック（fmt/validate）を実行します。
 - [ ] **マルチプラットフォーム デプロイ基盤**: GitHub Actions + Terraform による環境展開（クラウド別ターゲット対応）
 - [x] **MySQL/PostgreSQL の自動テスト**: 両 DB でのインテグレーションテスト追加
 - [x] **Docker イメージの軽量化**: マルチステージビルドの最適化（API/Crawler）
-- [ ] **Kubernetes 連携**: コンテナ連携・オーケストレーション対応（Helm/Kustomize 含む）
+- [ ] **Kubernetes 連携**: コンテナ連携・オーケストレーション対応（Helm/Kustomize/ArgoCD 含む）
 - [x] **API ドキュメントの拡充**: Swagger/OpenAPI による仕様書生成
 
-### v0.8.1 フォーカス（デプロイ基盤の仕上げ）
+### v0.8.x フォーカス（デプロイ基盤の仕上げ）
 
 - [x] **AWS先行IaC運用**: GitHub Actions + Terraform の `validate/plan/apply/destroy` を `dev` で実行可能化
 - [x] **環境分離**: `dev/stg/prod` の `aws.tfvars` を追加
 - [x] **オフライン検証経路**: AWSシークレット未設定でも `plan` を実行できる導線を整備
 - [x] **ロールバック運用**: `destroy` 手順を runbook 化し、実行証跡を追加
 - [ ] **マルチクラウド再拡張**: GCP/Azure ターゲットの再導入
-- [ ] **Kubernetes最小構成**: Helm/Kustomize 雛形の追加
+- [x] **Kubernetes最小構成**: Helm/Kustomize/ArgoCD 雛形の追加（`deploy/helm/postal-converter-ja`, `deploy/k8s/base`, `deploy/argocd`）
 
 ## バージョン
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,40 +1,43 @@
-# v0.7.0 (Beta) - Sales-ready onboarding kit
+# v0.8.0 (Beta) - AWS-first deployment baseline
 
 ## 概要
 
-`v0.7.0` は「導入加速」に焦点を当てたリリースです。  
-ローカル導入の再現性と、顧客向けデモの即応性を強化しました。
+`v0.8.0` は「デプロイ基盤」に焦点を当てたリリースです。  
+GitHub Actions + Terraform を AWS 先行で固定し、`plan/apply/destroy` の運用経路を整備しました。
 
 ## 主な変更点
 
-### 1. 導入SDKサンプルの拡張
+### 1. AWS 先行の CI/CD IaC パイプライン
 
-- Frontend の導入サンプルを 3 ユースケース構成に拡張:
-  - EC 配送フォーム
-  - 会員登録フォーム
-  - コールセンター入力支援フォーム
+- `.github/workflows/terraform-multiplatform.yml` を AWS baseline に整理
+- `workflow_dispatch` で `validate/plan/apply/destroy` を実行可能化
+- `apply` は `APPLY_AWS`、`destroy` は `DESTROY_AWS` の確認トークン必須
 
-### 2. 導入・運用ドキュメントの標準化
+### 2. OIDC と環境分離
 
-- 受託導入向けチェックリストを追加:
-  - `docs/CONTRACTOR_ONBOARDING_CHECKLIST.md`
-- SQLite 月次運用チェックリストを追加:
-  - `docs/SQLITE_MONTHLY_OPERATION_CHECKLIST.md`
-- v0.7.0 以降の実行計画を追加:
-  - `docs/V0_7_TO_V1_EXECUTION_PLAN.md`
+- GitHub OIDC 前提で AWS AssumeRole 実行
+- `infra/terraform/environments/{dev,stg,prod}/aws.tfvars` を整備
+- skeleton モードでは `AWS_ROLE_TO_ASSUME` 未設定でも `plan` を実行可能
 
-### 3. オンボーディング実機証跡の追加
+### 3. ロールバック運用の標準化
 
-- 同一ホスト端末での `onboard -> curl -> stop` の証跡を追加:
-  - `docs/ONBOARDING_REHEARSAL_EVIDENCE.md`
+- `docs/DEPLOY.md` に rollback runbook（`destroy` 経路）を追加
+- 実行証跡を追加:
+  - `docs/TERRAFORM_OFFLINE_PLAN_EVIDENCE.md`
+  - `docs/TERRAFORM_ROLLBACK_REHEARSAL_EVIDENCE.md`
+
+### 4. 実行補助スクリプト改善
+
+- `scripts/run_terraform_workflow.sh` が `destroy` 対応
+- workflow run の監視時に run ID 解決のリトライを追加（取りこぼし対策）
 
 ## バージョン整合
 
-- README バッジを `0.7.0` に更新
-- `worker/api`, `worker/common`, `worker/crawler` の `Cargo.toml` を `0.7.0` に更新
-- `frontend/package.json` を `0.7.0` に更新
+- README/EN README バッジを `0.8.0` に更新
+- `worker/api`, `worker/common`, `worker/crawler` の `Cargo.toml` を `0.8.0` に更新
+- `frontend/package.json` を `0.8.0` に更新
 
-## 次の焦点 (v0.8.0)
+## 次の焦点 (v0.9.0)
 
-- GitHub Actions + Terraform の本番適用基盤を 1 クラウドに固定して完成させる
-- OIDC を前提に `plan/apply` 再現性を高める
+- SLO/SLI と障害時運用（Runbook/監査）の強化
+- 監視・運用自動化の標準化

--- a/deploy/argocd/README.md
+++ b/deploy/argocd/README.md
@@ -1,0 +1,15 @@
+# ArgoCD Route (v0.8.2)
+
+Apply the Application resource:
+
+```bash
+kubectl apply -f deploy/argocd/application-postal-converter-ja.yaml
+```
+
+This tracks:
+
+- repo: `https://github.com/mt4110/postal_converter_ja.git`
+- path: `deploy/helm/postal-converter-ja`
+- targetRevision: `main`
+
+For branch validation, update `targetRevision` to your feature branch.

--- a/deploy/argocd/README.md
+++ b/deploy/argocd/README.md
@@ -1,4 +1,4 @@
-# ArgoCD Route (v0.8.2)
+# ArgoCD Route (v0.8.3)
 
 Apply the Application resource:
 
@@ -6,10 +6,22 @@ Apply the Application resource:
 kubectl apply -f deploy/argocd/application-postal-converter-ja.yaml
 ```
 
-This tracks:
+This creates 3 ArgoCD Applications:
+
+- `postal-converter-ja-dev` -> namespace `postal-converter-ja-dev`
+- `postal-converter-ja-stg` -> namespace `postal-converter-ja-stg`
+- `postal-converter-ja-prod` -> namespace `postal-converter-ja-prod`
+
+Shared source configuration:
 
 - repo: `https://github.com/mt4110/postal_converter_ja.git`
 - path: `deploy/helm/postal-converter-ja`
 - targetRevision: `main`
+
+Environment defaults:
+
+- dev: `replicaCount=1`
+- stg: `replicaCount=1`
+- prod: `replicaCount=2`
 
 For branch validation, update `targetRevision` to your feature branch.

--- a/deploy/argocd/application-postal-converter-ja.yaml
+++ b/deploy/argocd/application-postal-converter-ja.yaml
@@ -1,8 +1,11 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: postal-converter-ja
+  name: postal-converter-ja-dev
   namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: postal-converter-ja
+    env: dev
 spec:
   project: default
   source:
@@ -11,9 +14,70 @@ spec:
     path: deploy/helm/postal-converter-ja
     helm:
       releaseName: postal-converter-ja
+      parameters:
+        - name: replicaCount
+          value: "1"
   destination:
     server: https://kubernetes.default.svc
-    namespace: postal-converter-ja
+    namespace: postal-converter-ja-dev
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: postal-converter-ja-stg
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: postal-converter-ja
+    env: stg
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/mt4110/postal_converter_ja.git
+    targetRevision: main
+    path: deploy/helm/postal-converter-ja
+    helm:
+      releaseName: postal-converter-ja
+      parameters:
+        - name: replicaCount
+          value: "1"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: postal-converter-ja-stg
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: postal-converter-ja-prod
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: postal-converter-ja
+    env: prod
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/mt4110/postal_converter_ja.git
+    targetRevision: main
+    path: deploy/helm/postal-converter-ja
+    helm:
+      releaseName: postal-converter-ja
+      parameters:
+        - name: replicaCount
+          value: "2"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: postal-converter-ja-prod
   syncPolicy:
     automated:
       prune: true

--- a/deploy/argocd/application-postal-converter-ja.yaml
+++ b/deploy/argocd/application-postal-converter-ja.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: postal-converter-ja
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/mt4110/postal_converter_ja.git
+    targetRevision: main
+    path: deploy/helm/postal-converter-ja
+    helm:
+      releaseName: postal-converter-ja
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: postal-converter-ja
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/deploy/helm/postal-converter-ja/Chart.yaml
+++ b/deploy/helm/postal-converter-ja/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: postal-converter-ja
+description: Minimal Helm chart skeleton for Postal Converter JA API
+type: application
+version: 0.1.0
+appVersion: "0.8.2"

--- a/deploy/helm/postal-converter-ja/README.md
+++ b/deploy/helm/postal-converter-ja/README.md
@@ -1,0 +1,17 @@
+# Helm Skeleton (v0.8.2)
+
+Minimal chart for API deployment.
+
+## Lint
+
+```bash
+helm lint deploy/helm/postal-converter-ja
+```
+
+## Install
+
+```bash
+helm upgrade --install postal-converter-ja deploy/helm/postal-converter-ja \
+  --namespace postal-converter-ja \
+  --create-namespace
+```

--- a/deploy/helm/postal-converter-ja/templates/NOTES.txt
+++ b/deploy/helm/postal-converter-ja/templates/NOTES.txt
@@ -1,0 +1,4 @@
+1. Get the application URL by running these commands:
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/name={{ include "postal-converter-ja.name" . }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl --namespace {{ .Release.Namespace }} port-forward service/{{ include "postal-converter-ja.fullname" . }} 3202:{{ .Values.service.port }}
+  curl -fsS http://127.0.0.1:3202/health

--- a/deploy/helm/postal-converter-ja/templates/_helpers.tpl
+++ b/deploy/helm/postal-converter-ja/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{- define "postal-converter-ja.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "postal-converter-ja.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "postal-converter-ja.labels" -}}
+app.kubernetes.io/name: {{ include "postal-converter-ja.name" . }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "postal-converter-ja.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "postal-converter-ja.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/deploy/helm/postal-converter-ja/templates/configmap.yaml
+++ b/deploy/helm/postal-converter-ja/templates/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "postal-converter-ja.fullname" . }}-config
+  labels:
+    {{- include "postal-converter-ja.labels" . | nindent 4 }}
+data:
+  DATABASE_TYPE: {{ .Values.config.DATABASE_TYPE | quote }}
+  REDIS_CACHE_TTL_SECONDS: {{ .Values.config.REDIS_CACHE_TTL_SECONDS | quote }}
+  READY_REQUIRE_CACHE: {{ .Values.config.READY_REQUIRE_CACHE | quote }}
+  TRUST_PROXY_HEADERS: {{ .Values.config.TRUST_PROXY_HEADERS | quote }}
+  AUTH_MODE: {{ .Values.config.AUTH_MODE | quote }}
+  AUTH_USER_HEADER: {{ .Values.config.AUTH_USER_HEADER | quote }}
+  AUTH_GROUPS_HEADER: {{ .Values.config.AUTH_GROUPS_HEADER | quote }}
+  AUTH_ANONYMOUS_PATHS: {{ .Values.config.AUTH_ANONYMOUS_PATHS | quote }}

--- a/deploy/helm/postal-converter-ja/templates/deployment.yaml
+++ b/deploy/helm/postal-converter-ja/templates/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "postal-converter-ja.fullname" . }}
+  labels:
+    {{- include "postal-converter-ja.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "postal-converter-ja.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "postal-converter-ja.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      containers:
+        - name: api
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "postal-converter-ja.fullname" . }}-config
+            {{- if .Values.secret.create }}
+            - secretRef:
+                name: {{ include "postal-converter-ja.fullname" . }}-secret
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 10001
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/postal-converter-ja/templates/secret.yaml
+++ b/deploy/helm/postal-converter-ja/templates/secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.secret.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "postal-converter-ja.fullname" . }}-secret
+  labels:
+    {{- include "postal-converter-ja.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  POSTGRES_DATABASE_URL: {{ .Values.secret.POSTGRES_DATABASE_URL | quote }}
+  MYSQL_DATABASE_URL: {{ .Values.secret.MYSQL_DATABASE_URL | quote }}
+  SQLITE_DATABASE_PATH: {{ .Values.secret.SQLITE_DATABASE_PATH | quote }}
+  REDIS_URL: {{ .Values.secret.REDIS_URL | quote }}
+{{- end }}

--- a/deploy/helm/postal-converter-ja/templates/service.yaml
+++ b/deploy/helm/postal-converter-ja/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "postal-converter-ja.fullname" . }}
+  labels:
+    {{- include "postal-converter-ja.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "postal-converter-ja.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.service.port }}
+      targetPort: http

--- a/deploy/helm/postal-converter-ja/values.yaml
+++ b/deploy/helm/postal-converter-ja/values.yaml
@@ -1,0 +1,44 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/mt4110/postal_converter_ja/api
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+service:
+  type: ClusterIP
+  port: 3202
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+config:
+  DATABASE_TYPE: "postgres"
+  REDIS_CACHE_TTL_SECONDS: "300"
+  READY_REQUIRE_CACHE: "false"
+  TRUST_PROXY_HEADERS: "false"
+  AUTH_MODE: "none"
+  AUTH_USER_HEADER: "x-auth-request-email"
+  AUTH_GROUPS_HEADER: ""
+  AUTH_ANONYMOUS_PATHS: "/health,/ready,/openapi.json,/docs"
+
+secret:
+  create: true
+  POSTGRES_DATABASE_URL: "postgres://postgres:postgres_password@postgres:5432/zip_code_db"
+  MYSQL_DATABASE_URL: "mysql://mysql_user:u_password@mysql:3306/zip_code_db"
+  SQLITE_DATABASE_PATH: "/data/postal_codes.sqlite3"
+  REDIS_URL: "redis://redis:6379"
+
+podAnnotations: {}
+podLabels: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+nameOverride: ""
+fullnameOverride: ""

--- a/deploy/k8s/base/README.md
+++ b/deploy/k8s/base/README.md
@@ -1,0 +1,24 @@
+# Kubernetes Base Skeleton (v0.8.2)
+
+This directory provides a minimal Kustomize base for the API service.
+For default deployment, use Helm chart at `deploy/helm/postal-converter-ja`.
+
+## Apply
+
+```bash
+kubectl apply -k deploy/k8s/base
+```
+
+## Verify
+
+```bash
+kubectl -n postal-converter-ja get pods,svc
+kubectl -n postal-converter-ja port-forward svc/postal-converter-api 3202:3202
+curl -fsS http://127.0.0.1:3202/health
+```
+
+## Notes
+
+- This is a starter skeleton, not production-hardening.
+- Replace `image` in `deployment.yaml` before use.
+- Replace values in `secret.yaml` for your environment.

--- a/deploy/k8s/base/configmap.yaml
+++ b/deploy/k8s/base/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postal-converter-config
+  labels:
+    app.kubernetes.io/name: postal-converter-ja
+data:
+  DATABASE_TYPE: postgres
+  REDIS_CACHE_TTL_SECONDS: "300"
+  READY_REQUIRE_CACHE: "false"
+  TRUST_PROXY_HEADERS: "false"
+  AUTH_MODE: none
+  AUTH_USER_HEADER: x-auth-request-email
+  AUTH_GROUPS_HEADER: ""
+  AUTH_ANONYMOUS_PATHS: /health,/ready,/openapi.json,/docs

--- a/deploy/k8s/base/deployment.yaml
+++ b/deploy/k8s/base/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postal-converter-api
+  labels:
+    app.kubernetes.io/name: postal-converter-ja
+    app.kubernetes.io/component: api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postal-converter-ja
+      app.kubernetes.io/component: api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postal-converter-ja
+        app.kubernetes.io/component: api
+    spec:
+      containers:
+        - name: api
+          image: ghcr.io/mt4110/postal_converter_ja/api:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3202
+              name: http
+          envFrom:
+            - configMapRef:
+                name: postal-converter-config
+            - secretRef:
+                name: postal-converter-secret
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 10001

--- a/deploy/k8s/base/kustomization.yaml
+++ b/deploy/k8s/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: postal-converter-ja
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - secret.yaml
+  - deployment.yaml
+  - service.yaml

--- a/deploy/k8s/base/namespace.yaml
+++ b/deploy/k8s/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: postal-converter-ja
+  labels:
+    app.kubernetes.io/name: postal-converter-ja

--- a/deploy/k8s/base/secret.yaml
+++ b/deploy/k8s/base/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postal-converter-secret
+  labels:
+    app.kubernetes.io/name: postal-converter-ja
+type: Opaque
+stringData:
+  POSTGRES_DATABASE_URL: postgres://postgres:postgres_password@postgres:5432/zip_code_db
+  MYSQL_DATABASE_URL: mysql://mysql_user:u_password@mysql:3306/zip_code_db
+  SQLITE_DATABASE_PATH: /data/postal_codes.sqlite3
+  REDIS_URL: redis://redis:6379

--- a/deploy/k8s/base/service.yaml
+++ b/deploy/k8s/base/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postal-converter-api
+  labels:
+    app.kubernetes.io/name: postal-converter-ja
+    app.kubernetes.io/component: api
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: postal-converter-ja
+    app.kubernetes.io/component: api
+  ports:
+    - name: http
+      protocol: TCP
+      port: 3202
+      targetPort: http

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -114,3 +114,15 @@ nix develop --command terraform -chdir=infra/terraform/platforms/aws validate
 ## 6. 実行証跡 (v0.8.0)
 
 - offline plan 証跡: `docs/TERRAFORM_OFFLINE_PLAN_EVIDENCE.md`
+- rollback rehearsal 証跡: `docs/TERRAFORM_ROLLBACK_REHEARSAL_EVIDENCE.md`
+
+## 7. Rollback Path (v0.8.0 minimum)
+
+Skeleton 段階では、rollback は `terraform destroy` を最小経路とします。
+
+```bash
+terraform -chdir=infra/terraform/platforms/aws apply -auto-approve -refresh=false -input=false -lock=false -var-file=../../environments/dev/aws.tfvars
+terraform -chdir=infra/terraform/platforms/aws destroy -auto-approve -refresh=false -input=false -lock=false -var-file=../../environments/dev/aws.tfvars
+```
+
+実AWS運用に入った後（OIDC + 実リソースあり）は、同じ経路で `dev` から先に検証してから `stg/prod` に展開します。

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -110,3 +110,7 @@ nix develop --command terraform -chdir=infra/terraform/platforms/aws init -backe
 nix develop --command terraform -chdir=infra/terraform/platforms/aws validate
 
 ```
+
+## 6. 実行証跡 (v0.8.0)
+
+- offline plan 証跡: `docs/TERRAFORM_OFFLINE_PLAN_EVIDENCE.md`

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -94,8 +94,13 @@ AWS Secrets/Variables をまとめて設定する場合:
 
 ## 5. ローカル検証
 
+`terraform` がローカルシェルで見えない場合は Nix dev shell 経由で実行してください（Nix では OpenTofu 互換の `terraform` コマンドを提供）。
+Homebrew の `terraform` は 1.5.7 で固定される場合があるため、バージョン差異回避のためにも Nix 利用を推奨します。
+
 ```bash
-terraform -chdir=infra/terraform/platforms/aws init -backend=false
-terraform -chdir=infra/terraform/platforms/aws validate
+nix develop --command terraform version
+nix develop --command terraform fmt -check -recursive infra/terraform
+nix develop --command terraform -chdir=infra/terraform/platforms/aws init -backend=false
+nix develop --command terraform -chdir=infra/terraform/platforms/aws validate
 
 ```

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -25,7 +25,8 @@
 ### 手動実行 (workflow_dispatch)
 
 `action=plan` を選ぶと、AWS で `terraform plan` を実行します。  
-`action=apply` を選ぶと、AWS で `terraform apply` を実行します（確認トークン必須）。
+`action=apply` を選ぶと、AWS で `terraform apply` を実行します（確認トークン必須）。  
+`action=destroy` を選ぶと、AWS で `terraform destroy` を実行します（確認トークン必須）。
 
 - `AWS_ROLE_TO_ASSUME` が未設定の場合: `plan` は offline mode で実行（Skeleton検証用途）
 - `AWS_ROLE_TO_ASSUME` が設定済みの場合: OIDC で AssumeRole して `plan/apply` を実行
@@ -41,6 +42,9 @@ CLI から実行する場合:
 
 # apply (AWS only)
 ./scripts/run_terraform_workflow.sh --action apply --environment dev --confirm-apply APPLY_AWS --ref feature/v0.8.0
+
+# destroy (AWS only)
+./scripts/run_terraform_workflow.sh --action destroy --environment dev --confirm-destroy DESTROY_AWS --ref feature/v0.8.0
 ```
 
 ## 3. v0.8.0 の運用方針
@@ -56,7 +60,7 @@ CLI から実行する場合:
 - Secret: `AWS_ROLE_TO_ASSUME`
 - Variable: `AWS_REGION` (未設定時は `ap-northeast-1`)
 
-`apply` を実行するには AWS アカウントと IAM Role（OIDC trust policy 設定済み）が必須です。  
+`apply` / `destroy` を実行するには AWS アカウントと IAM Role（OIDC trust policy 設定済み）が必須です。  
 `plan` は Skeleton 段階では secret 未設定でも実行できます（offline mode）。
 
 GitHub Actions では `aws-actions/configure-aws-credentials@v4` を使い、OIDC で AssumeRole します。
@@ -123,6 +127,12 @@ Skeleton 段階では、rollback は `terraform destroy` を最小経路とし�
 ```bash
 terraform -chdir=infra/terraform/platforms/aws apply -auto-approve -refresh=false -input=false -lock=false -var-file=../../environments/dev/aws.tfvars
 terraform -chdir=infra/terraform/platforms/aws destroy -auto-approve -refresh=false -input=false -lock=false -var-file=../../environments/dev/aws.tfvars
+```
+
+GitHub Actions から実行する場合（確認トークン付き）:
+
+```bash
+./scripts/run_terraform_workflow.sh --action destroy --environment dev --confirm-destroy DESTROY_AWS --ref feature/v0.8.0
 ```
 
 実AWS運用に入った後（OIDC + 実リソースあり）は、同じ経路で `dev` から先に検証してから `stg/prod` に展開します。

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -27,6 +27,9 @@
 `action=plan` を選ぶと、AWS で `terraform plan` を実行します。  
 `action=apply` を選ぶと、AWS で `terraform apply` を実行します（確認トークン必須）。
 
+- `AWS_ROLE_TO_ASSUME` が未設定の場合: `plan` は offline mode で実行（Skeleton検証用途）
+- `AWS_ROLE_TO_ASSUME` が設定済みの場合: OIDC で AssumeRole して `plan/apply` を実行
+
 CLI から実行する場合:
 
 ```bash
@@ -52,6 +55,9 @@ CLI から実行する場合:
 
 - Secret: `AWS_ROLE_TO_ASSUME`
 - Variable: `AWS_REGION` (未設定時は `ap-northeast-1`)
+
+`apply` を実行するには AWS アカウントと IAM Role（OIDC trust policy 設定済み）が必須です。  
+`plan` は Skeleton 段階では secret 未設定でも実行できます（offline mode）。
 
 GitHub Actions では `aws-actions/configure-aws-credentials@v4` を使い、OIDC で AssumeRole します。
 `workflow_dispatch` の `action=plan` 実行時、`matrix.platform == aws` で有効になります。

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,20 +1,16 @@
-# Deployment Guide (GitHub Actions + Terraform Skeleton)
+# Deployment Guide (GitHub Actions + Terraform AWS Baseline)
 
 最終更新: 2026-02-12
 
-このドキュメントは、`GitHub Actions + Terraform` でマルチプラットフォーム展開へ進めるための最小骨格を説明します。
+このドキュメントは、`GitHub Actions + Terraform` で AWS を先行ターゲットとして運用する最小構成を説明します。
 
 ## 1. 追加された骨格
 
-- Workflow: `.github/workflows/terraform-multiplatform.yml`
+- Workflow: `.github/workflows/terraform-multiplatform.yml` (AWS baseline)
 - Terraform root modules:
   - `infra/terraform/platforms/aws`
-  - `infra/terraform/platforms/gcp`
-  - `infra/terraform/platforms/azure`
 - サンプル変数:
   - `infra/terraform/environments/dev/aws.tfvars`
-  - `infra/terraform/environments/dev/gcp.tfvars`
-  - `infra/terraform/environments/dev/azure.tfvars`
 
 ## 2. GitHub Actions の使い方
 
@@ -24,39 +20,31 @@
 - `terraform init -backend=false`
 - `terraform validate`
 
-を `aws/gcp/azure` で実行します。
+を `aws` で実行します。
 
 ### 手動実行 (workflow_dispatch)
 
-`action=plan` を選ぶと、3プラットフォームで `terraform plan` を実行します。
-`action=apply` を選ぶと、AWS のみ `terraform apply` を実行します（確認トークン必須）。
-
-> `gcp.tfvars` の `project_id = "replace-me"` が未置換の場合は、意図的に `plan` をスキップします。
+`action=plan` を選ぶと、AWS で `terraform plan` を実行します。  
+`action=apply` を選ぶと、AWS で `terraform apply` を実行します（確認トークン必須）。
 
 CLI から実行する場合:
 
 ```bash
 # validate
-./scripts/run_terraform_workflow.sh --action validate --environment dev --ref codex/feature/v0.3.0
+./scripts/run_terraform_workflow.sh --action validate --environment dev --ref feature/v0.8.0
 
 # plan
-./scripts/run_terraform_workflow.sh --action plan --environment dev --ref codex/feature/v0.3.0
+./scripts/run_terraform_workflow.sh --action plan --environment dev --ref feature/v0.8.0
 
 # apply (AWS only)
-./scripts/run_terraform_workflow.sh --action apply --environment dev --confirm-apply APPLY_AWS --ref codex/feature/v0.3.0
+./scripts/run_terraform_workflow.sh --action apply --environment dev --confirm-apply APPLY_AWS --ref feature/v0.8.0
 ```
 
-## 3. #Node TODO の意味
+## 3. v0.8.0 の運用方針
 
-今回の骨格には `#Node:` コメントを入れてあり、そのまま次タスクのノードとして使えます。
-
-- `AWS OIDC`: 実装済み
-- `#Node: module "network"...`
-- `#Node: module "api_runtime"...`
-- `GCP OIDC`: 実装済み
-- `Azure OIDC`: 実装済み
-
-この `#Node:` を順に実装していくと、`validate -> plan -> apply` の順で安全に拡張できます。
+- 先行ターゲットは AWS に固定
+- `validate -> plan -> apply` の順で dev 環境を安定化
+- GCP/Azure は v0.9+ で再導入
 
 ## 4. 次に設定する Secrets/Variables (実運用前)
 
@@ -94,25 +82,7 @@ IAM Role 側の trust policy は最小で以下をベースにしてください
 }
 ```
 
-### GCP
-
-- Secret: `GCP_WORKLOAD_IDENTITY_PROVIDER`
-- Secret: `GCP_SERVICE_ACCOUNT`
-- Variable: `GCP_PROJECT_ID`
-
-`google-github-actions/auth@v2` で Workload Identity Federation を利用します。
-`GCP_WORKLOAD_IDENTITY_PROVIDER` と `GCP_SERVICE_ACCOUNT` が未設定の場合、GCP の `plan` はスキップされます。
-
-### Azure
-
-- Secret: `AZURE_CLIENT_ID`
-- Secret: `AZURE_TENANT_ID`
-- Secret: `AZURE_SUBSCRIPTION_ID`
-
-`azure/login@v2` で OIDC ログインします。
-3つの Secret が未設定の場合、Azure の `plan` はスキップされます。
-
-Secrets/Variables をまとめて設定する場合:
+AWS Secrets/Variables をまとめて設定する場合:
 
 ```bash
 # dry-run (値を表示)
@@ -128,9 +98,4 @@ Secrets/Variables をまとめて設定する場合:
 terraform -chdir=infra/terraform/platforms/aws init -backend=false
 terraform -chdir=infra/terraform/platforms/aws validate
 
-terraform -chdir=infra/terraform/platforms/gcp init -backend=false
-terraform -chdir=infra/terraform/platforms/gcp validate
-
-terraform -chdir=infra/terraform/platforms/azure init -backend=false
-terraform -chdir=infra/terraform/platforms/azure validate
 ```

--- a/docs/ENGLISH_README.md
+++ b/docs/ENGLISH_README.md
@@ -196,6 +196,8 @@ Docs for developers:
 👉 [DEVELOPMENT.md](./DEVELOPMENT.md) _(Note: Currently in Japanese only.)_
 👉 [SQLITE_READONLY_POC.md](./SQLITE_READONLY_POC.md)
 👉 `.github/workflows/sqlite-release.yml` (manual workflow for SQLite release artifacts)
+👉 Kubernetes deployment guide (v0.8.2): [KUBERNETES_DEPLOYMENT.md](./KUBERNETES_DEPLOYMENT.md)
+👉 Kubernetes skeletons: `deploy/helm/postal-converter-ja` (Helm / default), `deploy/k8s/base` (Kustomize), `deploy/argocd` (ArgoCD route)
 
 ---
 
@@ -229,14 +231,15 @@ This model ensures sustainable development and fair support for long-term usage.
 - [x] OpenAPI/Swagger documentation
 - [x] Onboarding automation (`scripts/setup_nix_docker.sh`, `scripts/onboard.sh`)
 - [x] Deployment baseline (v0.8): AWS-first with GitHub Actions + Terraform
-- [ ] Kubernetes integration (Helm/Kustomize)
+- [ ] Kubernetes integration (Helm/Kustomize/ArgoCD)
 
-### v0.8.0 Focus (Deployment baseline)
+### v0.8.x Focus (Deployment baseline)
 
 - [x] AWS-first IaC flow: GitHub Actions + Terraform `validate/plan/apply` for dev
 - [x] Environment split: `dev/stg/prod` AWS tfvars
 - [x] Offline verification route: `plan` works without AWS secret in skeleton mode
 - [x] Rollback runbook: `destroy` command path with evidence
+- [x] Kubernetes minimum skeleton: Helm + Kustomize + ArgoCD scaffolding
 
 ---
 

--- a/docs/ENGLISH_README.md
+++ b/docs/ENGLISH_README.md
@@ -197,6 +197,7 @@ Docs for developers:
 👉 [SQLITE_READONLY_POC.md](./SQLITE_READONLY_POC.md)
 👉 `.github/workflows/sqlite-release.yml` (manual workflow for SQLite release artifacts)
 👉 Kubernetes deployment guide (v0.8.2): [KUBERNETES_DEPLOYMENT.md](./KUBERNETES_DEPLOYMENT.md)
+👉 Kubernetes adoption blueprint (existing platform ops): [K8S_ADOPTION_BLUEPRINT.md](./K8S_ADOPTION_BLUEPRINT.md)
 👉 Kubernetes skeletons: `deploy/helm/postal-converter-ja` (Helm / default), `deploy/k8s/base` (Kustomize), `deploy/argocd` (ArgoCD route)
 
 ---

--- a/docs/ENGLISH_README.md
+++ b/docs/ENGLISH_README.md
@@ -228,7 +228,7 @@ This model ensures sustainable development and fair support for long-term usage.
 - [x] Lightweight Docker images (multi-stage for API/Crawler)
 - [x] OpenAPI/Swagger documentation
 - [x] Onboarding automation (`scripts/setup_nix_docker.sh`, `scripts/onboard.sh`)
-- [ ] Multi-platform deployment baseline (GitHub Actions + Terraform)
+- [ ] Deployment baseline (v0.8): AWS-first with GitHub Actions + Terraform
 - [ ] Kubernetes integration (Helm/Kustomize)
 
 ### v0.7.0 Focus (Sales-ready onboarding)

--- a/docs/ENGLISH_README.md
+++ b/docs/ENGLISH_README.md
@@ -1,6 +1,6 @@
 # Postal Converter JA – Automatic Japanese Postal Code Updater
 
-![Version](https://img.shields.io/badge/version-0.7.0-blue.svg)
+![Version](https://img.shields.io/badge/version-0.8.0-blue.svg)
 ![Status](https://img.shields.io/badge/status-beta-orange.svg)
 
 **Postal Converter JA** is a fully automated system that fetches and updates the latest Japanese postal code data from Japan Post.  
@@ -228,15 +228,15 @@ This model ensures sustainable development and fair support for long-term usage.
 - [x] Lightweight Docker images (multi-stage for API/Crawler)
 - [x] OpenAPI/Swagger documentation
 - [x] Onboarding automation (`scripts/setup_nix_docker.sh`, `scripts/onboard.sh`)
-- [ ] Deployment baseline (v0.8): AWS-first with GitHub Actions + Terraform
+- [x] Deployment baseline (v0.8): AWS-first with GitHub Actions + Terraform
 - [ ] Kubernetes integration (Helm/Kustomize)
 
-### v0.7.0 Focus (Sales-ready onboarding)
+### v0.8.0 Focus (Deployment baseline)
 
-- [x] SDK samples for 3 use cases: EC checkout, member registration, call-center input support
-- [x] Delivery checklist for contractor onboarding (`docs/CONTRACTOR_ONBOARDING_CHECKLIST.md`)
-- [x] Host-terminal onboarding rehearsal evidence (`docs/ONBOARDING_REHEARSAL_EVIDENCE.md`)
-- [x] Monthly SQLite release operation checklist (`docs/SQLITE_MONTHLY_OPERATION_CHECKLIST.md`)
+- [x] AWS-first IaC flow: GitHub Actions + Terraform `validate/plan/apply` for dev
+- [x] Environment split: `dev/stg/prod` AWS tfvars
+- [x] Offline verification route: `plan` works without AWS secret in skeleton mode
+- [x] Rollback runbook: `destroy` command path with evidence
 
 ---
 

--- a/docs/HANDOFF_v0.8.3.md
+++ b/docs/HANDOFF_v0.8.3.md
@@ -1,0 +1,34 @@
+# Handoff for v0.8.3
+
+## 現在地点（v0.8.2）
+
+- Helm デフォルトの Kubernetes 雛形を追加済み
+- Kustomize base を追加済み
+- ArgoCD Application 雛形を追加済み
+- 既存運用向け導入設計図を追加済み（`K8S_ADOPTION_BLUEPRINT.md`）
+
+## v0.8.3 で優先する TODO
+
+1. Helm lint / template を CI に追加（`deploy/helm/postal-converter-ja`）
+2. ArgoCD `Application` の環境別化（dev/stg/prod の分離）
+3. Secret の平文排除（External Secrets 連携の雛形）
+4. Ingress と NetworkPolicy の最小テンプレート追加
+5. 導入リハーサル証跡（同一端末で `deploy -> health/ready`）を docs 化
+
+## マイルストーン整合
+
+- v0.8.x:
+  - デプロイ基盤仕上げ（AWS先行 + Kubernetes最小運用ルート）
+- v0.9.0:
+  - マルチクラウド再拡張（GCP/Azure）と運用強化
+- v1.0.0:
+  - 商用導入標準化（運用Runbook、監査、サポートフロー固定）
+
+## 次スレ冒頭メッセージ（コピペ用）
+
+```text
+feature/v0.8.3 で開始します。
+v0.8.2 は Helm/Kustomize/ArgoCD の最小雛形と導入設計図まで完了しています。
+次は v0.8.3 の1タスク目として「Helm lint/template を CI に追加」から進めてください。
+完了後は 1コミット単位で差分確認し、push/PR まで進めます。
+```

--- a/docs/K8S_ADOPTION_BLUEPRINT.md
+++ b/docs/K8S_ADOPTION_BLUEPRINT.md
@@ -1,0 +1,172 @@
+# K8S Adoption Blueprint (v0.8.2)
+
+既存の Kubernetes 運用基盤に `postal_converter_ja` を安全に組み込むための設計図です。
+
+## 1. 設計図（全体像）
+
+```mermaid
+flowchart LR
+  GH["GitHub Container Registry"] --> ARGO["ArgoCD (GitOps)"]
+  ARGO --> HELM["Helm Chart: deploy/helm/postal-converter-ja"]
+  HELM --> NS["Namespace: postal-converter-ja"]
+  NS --> DEP["Deployment: postal-converter-api"]
+  DEP --> SVC["Service: ClusterIP :3202"]
+  INGRESS["Ingress / Gateway"] --> SVC
+  DEP --> DB["Managed DB (PostgreSQL/MySQL)"]
+  DEP --> REDIS["Redis (optional)"]
+  DEP --> METRICS["/metrics + /ready + /health"]
+  METRICS --> OBS["Observability (Prometheus/Loki/APM)"]
+  SECOPS["Secret Manager / External Secrets"] --> DEP
+```
+
+## 2. 責務分離（運用しやすい構成）
+
+- アプリ責務:
+  - API Pod の稼働、`/health` と `/ready` 提供、`/metrics` 出力
+- プラットフォーム責務:
+  - Ingress/Gateway、証明書、WAF、ネットワークポリシー
+  - Secret 配布（External Secrets / Sealed Secrets）
+  - 監視・アラート基盤（Prometheus/Grafana/Loki など）
+
+## 3. ネットワーク設計
+
+- Ingress/Gateway -> `postal-converter-ja` Namespace 内 Service (`ClusterIP`)
+- 外部公開は Ingress でのみ実施（Service を `LoadBalancer` にしない）
+- 推奨:
+  - Namespace 単位で NetworkPolicy を適用
+  - Egress を DB/Redis 先に限定
+
+## 4. Secret 設計
+
+`values.yaml` の Secret 値はサンプルです。実運用では以下に置換:
+
+- `POSTGRES_DATABASE_URL`
+- `MYSQL_DATABASE_URL`
+- `REDIS_URL`
+- 必要時 `SQLITE_DATABASE_PATH`
+
+推奨ルート:
+
+- External Secrets Operator + AWS Secrets Manager / GCP Secret Manager
+- もしくは SOPS + Git 管理
+
+## 5. 監視設計
+
+- Liveness: `/health`
+- Readiness: `/ready`
+- Metrics: `/metrics` (JSON)
+
+最小監視項目:
+
+- `requests_total`
+- `errors_total`
+- `not_found_total`
+- `average_latency_ms`
+
+アラート例:
+
+- 5xx 比率が 5 分平均で閾値超過
+- `ready` 失敗継続
+- レイテンシ悪化
+
+## 6. ロールバック設計
+
+Helm ルート:
+
+```bash
+helm -n postal-converter-ja history postal-converter-ja
+helm -n postal-converter-ja rollback postal-converter-ja <REVISION>
+```
+
+ArgoCD ルート:
+
+```bash
+argocd app history postal-converter-ja
+argocd app rollback postal-converter-ja <ID>
+```
+
+共通:
+
+- DBスキーマ変更を伴う場合は、アプリロールバック前に互換性確認
+- Secret ローテーション直後の障害は直前バージョンへ戻す
+
+## 7. 導入手順（既存Kubernetes運用へ投入）
+
+### Step 0: 事前確認
+
+```bash
+kubectl version --client
+kubectl config current-context
+helm version
+```
+
+### Step 1: values オーバーライドを作成
+
+`deploy/helm/postal-converter-ja/values-prod.yaml` を新規作成:
+
+```yaml
+image:
+  repository: ghcr.io/mt4110/postal_converter_ja/api
+  tag: "v0.8.2"
+
+config:
+  DATABASE_TYPE: "postgres"
+  READY_REQUIRE_CACHE: "true"
+
+secret:
+  create: false
+```
+
+### Step 2: Secret を既存基盤で作成（例）
+
+```bash
+kubectl -n postal-converter-ja create secret generic postal-converter-ja-secret \
+  --from-literal=POSTGRES_DATABASE_URL='postgres://***' \
+  --from-literal=MYSQL_DATABASE_URL='mysql://***' \
+  --from-literal=REDIS_URL='redis://***' \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+### Step 3: マニフェスト差分確認（dry-run）
+
+```bash
+helm template postal-converter-ja deploy/helm/postal-converter-ja \
+  -n postal-converter-ja \
+  -f deploy/helm/postal-converter-ja/values.yaml \
+  -f deploy/helm/postal-converter-ja/values-prod.yaml > /tmp/postal-rendered.yaml
+```
+
+### Step 4: デプロイ
+
+```bash
+helm upgrade --install postal-converter-ja deploy/helm/postal-converter-ja \
+  -n postal-converter-ja \
+  --create-namespace \
+  -f deploy/helm/postal-converter-ja/values.yaml \
+  -f deploy/helm/postal-converter-ja/values-prod.yaml
+```
+
+### Step 5: 稼働確認
+
+```bash
+kubectl -n postal-converter-ja get deploy,po,svc
+kubectl -n postal-converter-ja rollout status deploy/postal-converter-ja
+kubectl -n postal-converter-ja port-forward svc/postal-converter-ja 3202:3202
+curl -fsS http://127.0.0.1:3202/health
+curl -fsS http://127.0.0.1:3202/ready
+```
+
+### Step 6: ArgoCD へ移行する場合
+
+```bash
+kubectl apply -f deploy/argocd/application-postal-converter-ja.yaml
+argocd app sync postal-converter-ja
+argocd app wait postal-converter-ja --health --operation
+```
+
+## 8. v0.8.2 の到達点
+
+- Helm デフォルト導入ルートを用意
+- Kustomize 最小雛形を用意
+- ArgoCD GitOps ルートを追加
+- 既存運用へ組み込む導入手順を定義

--- a/docs/KUBERNETES_DEPLOYMENT.md
+++ b/docs/KUBERNETES_DEPLOYMENT.md
@@ -1,0 +1,63 @@
+# Kubernetes Deployment Guide (v0.8.2)
+
+このドキュメントは、Postal Converter JA の Kubernetes 導入ルートを定義します。
+
+## 方針
+
+- デフォルト導入: Helm (`deploy/helm/postal-converter-ja`)
+- 補助ルート: Kustomize base (`deploy/k8s/base`)
+- GitOps運用: ArgoCD Application (`deploy/argocd/application-postal-converter-ja.yaml`)
+
+## 1) Helm（デフォルト）
+
+前提:
+
+- `kubectl` が利用可能
+- `helm` が利用可能
+
+```bash
+helm lint deploy/helm/postal-converter-ja
+
+helm upgrade --install postal-converter-ja deploy/helm/postal-converter-ja \
+  --namespace postal-converter-ja \
+  --create-namespace
+```
+
+疎通確認:
+
+```bash
+kubectl -n postal-converter-ja get pods,svc
+kubectl -n postal-converter-ja port-forward svc/postal-converter-ja 3202:3202
+curl -fsS http://127.0.0.1:3202/health
+curl -fsS http://127.0.0.1:3202/ready
+```
+
+## 2) Kustomize base（最小雛形）
+
+```bash
+kubectl apply -k deploy/k8s/base
+kubectl -n postal-converter-ja get pods,svc
+```
+
+## 3) ArgoCD（GitOps運用ルート）
+
+前提:
+
+- ArgoCD がクラスタにインストール済み
+
+```bash
+kubectl apply -f deploy/argocd/application-postal-converter-ja.yaml
+```
+
+ArgoCD CLI を使う場合:
+
+```bash
+argocd app get postal-converter-ja
+argocd app sync postal-converter-ja
+argocd app wait postal-converter-ja --health --operation
+```
+
+## 運用メモ
+
+- `values.yaml` の接続情報はサンプル値です。実運用では Secret 管理基盤（External Secrets, SOPS など）へ移行してください。
+- `image.repository` / `image.tag` はCI生成イメージに合わせて固定してください。

--- a/docs/ONBOARDING_REHEARSAL_EVIDENCE.md
+++ b/docs/ONBOARDING_REHEARSAL_EVIDENCE.md
@@ -1,7 +1,7 @@
 # Onboarding Rehearsal Evidence
 
 - Executed at (JST): 2026-02-13 13:51:44 JST
-- Branch: codex/feature/v0.7.0
+- Branch: feature/v0.7.0
 - Commit: 3176cc4
 
 ## 1) Start Command

--- a/docs/TERRAFORM_OFFLINE_PLAN_EVIDENCE.md
+++ b/docs/TERRAFORM_OFFLINE_PLAN_EVIDENCE.md
@@ -1,0 +1,51 @@
+# Terraform Offline Plan Evidence (v0.8.0)
+
+- Executed at (JST): 2026-02-13 16:12:07 JST
+- Branch: `feature/v0.8.0`
+- Commit: `07c47d9`
+- Mode: AWS credentials/secrets なしの offline plan 検証
+
+## Commands
+
+```bash
+terraform version
+terraform -chdir=infra/terraform/platforms/aws init -backend=false -no-color
+terraform -chdir=infra/terraform/platforms/aws validate -no-color
+terraform -chdir=infra/terraform/platforms/aws plan -refresh=false -input=false -lock=false -var-file=../../environments/dev/aws.tfvars -no-color
+terraform -chdir=infra/terraform/platforms/aws plan -refresh=false -input=false -lock=false -var-file=../../environments/stg/aws.tfvars -no-color
+terraform -chdir=infra/terraform/platforms/aws plan -refresh=false -input=false -lock=false -var-file=../../environments/prod/aws.tfvars -no-color
+```
+
+## Output (excerpt)
+
+```txt
+$ terraform version
+Terraform v1.14.5
+on darwin_arm64
+
+$ terraform -chdir=infra/terraform/platforms/aws init -backend=false -no-color
+Initializing provider plugins...
+- Reusing previous version of hashicorp/aws from the dependency lock file
+- Using previously-installed hashicorp/aws v5.100.0
+Terraform has been successfully initialized!
+
+$ terraform -chdir=infra/terraform/platforms/aws validate -no-color
+Success! The configuration is valid.
+
+$ terraform ... -var-file=../../environments/dev/aws.tfvars -no-color
+Changes to Outputs:
+  + skeleton_summary = "terraform skeleton ready: platform=aws, env=dev, region=ap-northeast-1"
+
+$ terraform ... -var-file=../../environments/stg/aws.tfvars -no-color
+Changes to Outputs:
+  + skeleton_summary = "terraform skeleton ready: platform=aws, env=stg, region=ap-northeast-1"
+
+$ terraform ... -var-file=../../environments/prod/aws.tfvars -no-color
+Changes to Outputs:
+  + skeleton_summary = "terraform skeleton ready: platform=aws, env=prod, region=ap-northeast-1"
+```
+
+## Result
+
+- `init` / `validate` / `plan(dev|stg|prod)` はすべて成功
+- AWS アカウント未接続でも v0.8.0 の Terraform skeleton 検証が可能であることを確認

--- a/docs/TERRAFORM_ROLLBACK_REHEARSAL_EVIDENCE.md
+++ b/docs/TERRAFORM_ROLLBACK_REHEARSAL_EVIDENCE.md
@@ -1,0 +1,46 @@
+# Terraform Rollback Rehearsal Evidence (v0.8.0)
+
+- Executed at (JST): 2026-02-13 16:58:52 JST
+- Branch: `feature/v0.8.0`
+- Commit: `bb6204e`
+- Mode: ローカル offline rehearsal（AWS credentials なし）
+
+## Goal
+
+`v0.8.0` の Exit Criteria にある「Deployment rollback path is documented and tested once」を満たすため、AWS未接続で `apply -> rollback(destroy)` を1回検証した。
+
+## Commands
+
+```bash
+terraform -chdir=infra/terraform/platforms/aws init -backend=false -no-color
+terraform -chdir=infra/terraform/platforms/aws apply -auto-approve -refresh=false -input=false -lock=false -var-file=../../environments/dev/aws.tfvars -no-color
+terraform -chdir=infra/terraform/platforms/aws output -no-color
+terraform -chdir=infra/terraform/platforms/aws destroy -auto-approve -refresh=false -input=false -lock=false -var-file=../../environments/dev/aws.tfvars -no-color
+terraform -chdir=infra/terraform/platforms/aws output -no-color || true
+```
+
+## Output (excerpt)
+
+```txt
+$ terraform ... apply ... -var-file=../../environments/dev/aws.tfvars -no-color
+Changes to Outputs:
+  + skeleton_summary = "terraform skeleton ready: platform=aws, env=dev, region=ap-northeast-1"
+Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
+
+$ terraform ... output -no-color
+skeleton_summary = "terraform skeleton ready: platform=aws, env=dev, region=ap-northeast-1"
+
+$ terraform ... destroy ... -var-file=../../environments/dev/aws.tfvars -no-color
+Changes to Outputs:
+  - skeleton_summary = "terraform skeleton ready: platform=aws, env=dev, region=ap-northeast-1" -> null
+Destroy complete! Resources: 0 destroyed.
+
+$ terraform ... output -no-color
+Warning: No outputs found
+```
+
+## Result
+
+- `apply` 後に `skeleton_summary` output が state に保存されることを確認
+- `destroy` 後に output が消えることを確認（rollback最小経路の検証完了）
+- 現段階（skeleton）では実リソース作成なしのため、`Resources: 0` は想定どおり

--- a/docs/V0_7_TO_V1_EXECUTION_PLAN.md
+++ b/docs/V0_7_TO_V1_EXECUTION_PLAN.md
@@ -66,13 +66,13 @@ Exit Criteria:
 - GA checklist is complete and signed off.
 - Version `v1.0.0` can be tagged with reproducible release steps.
 
-## Current Sprint (v0.7.0)
+## Current Sprint (v0.8.0)
 
-- [x] Add call-center SDK sample to frontend showcase
-- [x] Add contractor onboarding checklist doc
-- [x] Add monthly SQLite release operation checklist doc
-- [x] Validate onboarding flow and record evidence (`docs/ONBOARDING_REHEARSAL_EVIDENCE.md`)
+- [x] AWS-first Terraform workflow baseline (`validate/plan/apply`) for dev
+- [x] OIDC-based AssumeRole integration for GitHub Actions
+- [x] Environment separation (`dev/stg/prod` tfvars)
+- [x] Rollback path documentation + rehearsal evidence
 
 ## Next One Task
 
-1. Start v0.8.0 baseline: complete AWS-first Terraform plan/apply path for dev.
+1. Start v0.9.0: define SLO/SLI and first operations runbook set.

--- a/docs/V0_7_TO_V1_EXECUTION_PLAN.md
+++ b/docs/V0_7_TO_V1_EXECUTION_PLAN.md
@@ -75,4 +75,4 @@ Exit Criteria:
 
 ## Next One Task
 
-1. Start v0.8.0 baseline: select one primary cloud target for Terraform apply path.
+1. Start v0.8.0 baseline: complete AWS-first Terraform plan/apply path for dev.

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,11 @@
           extensions = [ "rust-src" "rust-analyzer" ];
         };
 
+        # Keep local command UX as `terraform` while using OSS OpenTofu in nix shell.
+        terraformCompat = pkgs.writeShellScriptBin "terraform" ''
+          exec ${pkgs.opentofu}/bin/tofu "$@"
+        '';
+
         # System dependencies
         buildInputs = with pkgs; [
           openssl
@@ -30,6 +35,8 @@
           nodejs_20
           yarn
           sqlite
+          opentofu
+          terraformCompat
         ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
           pkgs.libiconv
           pkgs.darwin.apple_sdk.frameworks.Security

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postal-frontend",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3203",

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,26 +1,20 @@
-# Terraform Multi-Platform Skeleton
+# Terraform AWS Baseline
 
-`infra/terraform` には、マルチプラットフォーム展開の最小骨格を配置しています。
+`infra/terraform` には、AWS 先行展開の最小骨格を配置しています。
 
 - `platforms/aws`: AWS 向け root module
-- `platforms/gcp`: GCP 向け root module
-- `platforms/azure`: Azure 向け root module
-- `environments/dev/*.tfvars`: dev 用の変数サンプル
+- `platforms/gcp`: 将来拡張用の骨格（現行 workflow 対象外）
+- `platforms/azure`: 将来拡張用の骨格（現行 workflow 対象外）
+- `environments/dev/aws.tfvars`: dev 用の変数サンプル
 
 ## Local Validate
 
 ```bash
 terraform -chdir=infra/terraform/platforms/aws init -backend=false
 terraform -chdir=infra/terraform/platforms/aws validate
-
-terraform -chdir=infra/terraform/platforms/gcp init -backend=false
-terraform -chdir=infra/terraform/platforms/gcp validate
-
-terraform -chdir=infra/terraform/platforms/azure init -backend=false
-terraform -chdir=infra/terraform/platforms/azure validate
 ```
 
 ## Notes
 
-- `#Node:` コメントは、この骨格から本実装へ進めるための TODO ノードです。
-- `gcp.tfvars` の `project_id = "replace-me"` は必ず実値に置換してください。
+- v0.8.0 は AWS に固定し、`validate -> plan -> apply` の再現性を優先します。
+- GCP/Azure は v0.9+ で段階的に再導入する前提です。

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -6,15 +6,18 @@
 - `platforms/gcp`: 将来拡張用の骨格（現行 workflow 対象外）
 - `platforms/azure`: 将来拡張用の骨格（現行 workflow 対象外）
 - `environments/dev/aws.tfvars`: dev 用の変数サンプル
+- `environments/stg/aws.tfvars`: stg 用の変数サンプル
+- `environments/prod/aws.tfvars`: prod 用の変数サンプル
 
 ## Local Validate
 
 ```bash
-terraform -chdir=infra/terraform/platforms/aws init -backend=false
-terraform -chdir=infra/terraform/platforms/aws validate
+nix develop --command terraform -chdir=infra/terraform/platforms/aws init -backend=false
+nix develop --command terraform -chdir=infra/terraform/platforms/aws validate
 ```
 
 ## Notes
 
 - v0.8.0 は AWS に固定し、`validate -> plan -> apply` の再現性を優先します。
+- `plan` は `AWS_ROLE_TO_ASSUME` 未設定時に offline mode で実行可能です（Skeleton検証用）。
 - GCP/Azure は v0.9+ で段階的に再導入する前提です。

--- a/infra/terraform/environments/prod/aws.tfvars
+++ b/infra/terraform/environments/prod/aws.tfvars
@@ -1,0 +1,3 @@
+environment  = "prod"
+service_name = "postal-converter-ja"
+region       = "ap-northeast-1"

--- a/infra/terraform/environments/stg/aws.tfvars
+++ b/infra/terraform/environments/stg/aws.tfvars
@@ -1,0 +1,3 @@
+environment  = "stg"
+service_name = "postal-converter-ja"
+region       = "ap-northeast-1"

--- a/infra/terraform/platforms/aws/.terraform.lock.hcl
+++ b/infra/terraform/platforms/aws/.terraform.lock.hcl
@@ -5,7 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"
   hashes = [
-    "h1:wOhTPz6apLBuF7/FYZuCoXRK/MLgrNprZ3vXmq83g5k=",
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
     "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
     "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",

--- a/scripts/run_terraform_workflow.sh
+++ b/scripts/run_terraform_workflow.sh
@@ -14,8 +14,8 @@ Usage:
   ./scripts/run_terraform_workflow.sh [--repo owner/repo] [--ref branch] --action validate|plan|apply [--environment dev|stg|prod] [--confirm-apply APPLY_AWS] [--no-watch]
 
 Examples:
-  ./scripts/run_terraform_workflow.sh --action plan --environment dev --ref codex/feature/v0.3.0
-  ./scripts/run_terraform_workflow.sh --action apply --environment dev --confirm-apply APPLY_AWS --ref codex/feature/v0.3.0
+  ./scripts/run_terraform_workflow.sh --action plan --environment dev --ref feature/v0.8.0
+  ./scripts/run_terraform_workflow.sh --action apply --environment dev --confirm-apply APPLY_AWS --ref feature/v0.8.0
 EOF
 }
 
@@ -126,7 +126,7 @@ if [ "${WATCH}" = true ]; then
   fi
 
   run_id="$(gh run list "${repo_args[@]}" \
-    --workflow "Terraform Multi-Platform Skeleton" \
+    --workflow "Terraform AWS Baseline" \
     --branch "${watch_branch}" \
     --limit 1 \
     --json databaseId \

--- a/scripts/run_terraform_workflow.sh
+++ b/scripts/run_terraform_workflow.sh
@@ -6,16 +6,18 @@ REF=""
 ENVIRONMENT="dev"
 ACTION="plan"
 CONFIRM_APPLY=""
+CONFIRM_DESTROY=""
 WATCH=true
 
 usage() {
   cat <<'EOF'
 Usage:
-  ./scripts/run_terraform_workflow.sh [--repo owner/repo] [--ref branch] --action validate|plan|apply [--environment dev|stg|prod] [--confirm-apply APPLY_AWS] [--no-watch]
+  ./scripts/run_terraform_workflow.sh [--repo owner/repo] [--ref branch] --action validate|plan|apply|destroy [--environment dev|stg|prod] [--confirm-apply APPLY_AWS] [--confirm-destroy DESTROY_AWS] [--no-watch]
 
 Examples:
   ./scripts/run_terraform_workflow.sh --action plan --environment dev --ref feature/v0.8.0
   ./scripts/run_terraform_workflow.sh --action apply --environment dev --confirm-apply APPLY_AWS --ref feature/v0.8.0
+  ./scripts/run_terraform_workflow.sh --action destroy --environment dev --confirm-destroy DESTROY_AWS --ref feature/v0.8.0
 EOF
 }
 
@@ -53,6 +55,10 @@ while [ "$#" -gt 0 ]; do
       CONFIRM_APPLY="${2:-}"
       shift 2
       ;;
+    --confirm-destroy)
+      CONFIRM_DESTROY="${2:-}"
+      shift 2
+      ;;
     --no-watch)
       WATCH=false
       shift
@@ -78,7 +84,7 @@ case "${ENVIRONMENT}" in
 esac
 
 case "${ACTION}" in
-  validate|plan|apply) ;;
+  validate|plan|apply|destroy) ;;
   *)
     echo "Invalid action: ${ACTION}"
     exit 1
@@ -107,10 +113,18 @@ if [ "${ACTION}" = "apply" ] && [ "${CONFIRM_APPLY}" != "APPLY_AWS" ]; then
   exit 1
 fi
 
+if [ "${ACTION}" = "destroy" ] && [ "${CONFIRM_DESTROY}" != "DESTROY_AWS" ]; then
+  echo "destroy requires --confirm-destroy DESTROY_AWS"
+  exit 1
+fi
+
+dispatch_epoch="$(date -u +%s)"
+
 gh workflow run terraform-multiplatform.yml "${repo_args[@]}" "${ref_args[@]}" \
   -f environment="${ENVIRONMENT}" \
   -f action="${ACTION}" \
-  -f confirm_apply="${CONFIRM_APPLY}"
+  -f confirm_apply="${CONFIRM_APPLY}" \
+  -f confirm_destroy="${CONFIRM_DESTROY}"
 
 echo "workflow dispatched: action=${ACTION}, environment=${ENVIRONMENT}"
 
@@ -125,15 +139,26 @@ if [ "${WATCH}" = true ]; then
     watch_branch="$(git rev-parse --abbrev-ref HEAD)"
   fi
 
-  run_id="$(gh run list "${repo_args[@]}" \
-    --workflow "Terraform AWS Baseline" \
-    --branch "${watch_branch}" \
-    --limit 1 \
-    --json databaseId \
-    | jq -r '.[0].databaseId')"
+  run_id=""
+  for _ in $(seq 1 15); do
+    run_id="$(gh run list "${repo_args[@]}" \
+      --workflow "Terraform AWS Baseline" \
+      --branch "${watch_branch}" \
+      --limit 20 \
+      --json databaseId,event,createdAt \
+      | jq -r --argjson t "${dispatch_epoch}" '
+          [.[] | select(.event=="workflow_dispatch") | select((.createdAt | fromdateiso8601) >= ($t - 60))][0].databaseId
+        ')"
+    if [ -n "${run_id}" ] && [ "${run_id}" != "null" ]; then
+      break
+    fi
+    sleep 2
+  done
 
   if [ -z "${run_id}" ] || [ "${run_id}" = "null" ]; then
     echo "Could not resolve latest run id for branch ${watch_branch}."
+    echo "Recent runs:"
+    gh run list "${repo_args[@]}" --workflow "Terraform AWS Baseline" --branch "${watch_branch}" --limit 5
     exit 1
   fi
 

--- a/worker/Cargo.lock
+++ b/worker/Cargo.lock
@@ -57,7 +57,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "api_service"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "axum",
  "common",
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "deadpool-postgres",
  "dotenv",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "crawler_service"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "common",

--- a/worker/api/Cargo.toml
+++ b/worker/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api_service"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 
 [dependencies]

--- a/worker/common/Cargo.toml
+++ b/worker/common/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "common"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 
 [dependencies]

--- a/worker/crawler/Cargo.toml
+++ b/worker/crawler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crawler_service"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- add a dedicated CI job for Helm validation
- run `helm lint` against `deploy/helm/postal-converter-ja`
- render manifests with `helm template` and fail if output is empty

## Why
- start v0.8.3 task 1 (Helm lint/template in CI) to catch chart regressions early

## Notes
- local helm execution was not possible in this environment because helm is not installed; CI installs helm via `azure/setup-helm`
