### PR TITLE
docs(ci): v0.8.4 runbooks and kubeconform CRD policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,8 +191,15 @@ jobs:
           test -s /tmp/postal-converter-ja-prod.yaml
 
       - name: kubeconform validate rendered manifests
+        env:
+          KUBECONFORM_ARGS: "-strict -summary -ignore-missing-schemas"
         run: |
-          kubeconform -strict -summary -ignore-missing-schemas /tmp/postal-converter-ja-default.yaml
-          kubeconform -strict -summary -ignore-missing-schemas /tmp/postal-converter-ja-dev.yaml
-          kubeconform -strict -summary -ignore-missing-schemas /tmp/postal-converter-ja-stg.yaml
-          kubeconform -strict -summary -ignore-missing-schemas /tmp/postal-converter-ja-prod.yaml
+          # CRD schema (e.g. ExternalSecret) may not be resolvable in CI network context.
+          # Policy: keep strict validation for core resources and allow missing CRD schemas.
+          for manifest in \
+            /tmp/postal-converter-ja-default.yaml \
+            /tmp/postal-converter-ja-dev.yaml \
+            /tmp/postal-converter-ja-stg.yaml \
+            /tmp/postal-converter-ja-prod.yaml; do
+            kubeconform ${KUBECONFORM_ARGS} "$manifest"
+          done

--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ SSOヘッダ認証（`AUTH_MODE=sso_header`）:
   - `deploy/k8s/base`（Kustomize）
   - `deploy/argocd`（ArgoCD route）
 - Kubernetes 導入リハーサル証跡（v0.8.3）: [K8S_REHEARSAL_EVIDENCE_v0.8.3.md](./docs/K8S_REHEARSAL_EVIDENCE_v0.8.3.md)
+- ExternalSecret 運用の最小 Runbook: [EXTERNAL_SECRETS_RUNBOOK.md](./docs/EXTERNAL_SECRETS_RUNBOOK.md)
+- v0.9 運用 Runbook ドラフト（SLO/SLI・一次対応）: [OPERATIONS_RUNBOOK_v0.9.md](./docs/OPERATIONS_RUNBOOK_v0.9.md)
 - v0.8 offline plan 証跡: [TERRAFORM_OFFLINE_PLAN_EVIDENCE.md](./docs/TERRAFORM_OFFLINE_PLAN_EVIDENCE.md)
 - v0.8 rollback 証跡: [TERRAFORM_ROLLBACK_REHEARSAL_EVIDENCE.md](./docs/TERRAFORM_ROLLBACK_REHEARSAL_EVIDENCE.md)
 

--- a/docs/CI_DESIGN.md
+++ b/docs/CI_DESIGN.md
@@ -55,3 +55,18 @@ We will add a new job `integration-test` to `.github/workflows/ci.yml`.
 ## 📈 Future Expansion (Optional)
 
 - **Weekly Full Test**: If we really want to test the _real_ Japan Post file (to catch format changes), we can create a separate Scheduled Workflow that runs once a week. This minimizes load while ensuring long-term compatibility.
+
+## Kubernetes Manifest Validation Policy (v0.8.4)
+
+Helm chart の回帰検知は `.github/workflows/ci.yml` の `helm` ジョブで行う。
+
+- `helm lint` を実行する。
+- `helm template` を `default/dev/stg/prod` の4パターンでレンダリングする。
+- `kubeconform` は `-strict -summary` を必須にし、型不整合を fail させる。
+- CRD（現時点では `ExternalSecret`）は標準スキーマ未提供ケースがあるため、`-ignore-missing-schemas` を併用する。
+
+運用ルール:
+
+- `-ignore-missing-schemas` は「CRD由来の未解決スキーマのみ」を許容するための例外として扱う。
+- 新規 CRD を導入した場合は、PR に「なぜこの例外が必要か」を記載する。
+- CRD の安定スキーマ配布元を固定できる段階になったら、`-ignore-missing-schemas` の解除を検討する。

--- a/docs/EXTERNAL_SECRETS_RUNBOOK.md
+++ b/docs/EXTERNAL_SECRETS_RUNBOOK.md
@@ -1,0 +1,134 @@
+# External Secrets Minimal Runbook (v0.8.4)
+
+この Runbook は、`postal_converter_ja` の Kubernetes 運用で External Secrets を使う最小手順を定義します。
+
+## 1. 前提
+
+- External Secrets Operator が導入済み。
+- 環境ごとに `ClusterSecretStore` が存在する:
+  - `postal-converter-ja-dev`
+  - `postal-converter-ja-stg`
+  - `postal-converter-ja-prod`
+- Helm values は `secret.create=false` を維持する。
+- Helm values は `externalSecret.enabled=true` を有効にする。
+
+## 2. 切替手順（平文 Secret から ExternalSecret へ）
+
+以下は `prod` 例。`dev/stg` では namespace と values を読み替える。
+
+1. 既存 Secret を退避:
+
+```bash
+kubectl -n postal-converter-ja-prod get secret postal-converter-ja-secret -o yaml > /tmp/postal-converter-ja-secret.backup.yaml
+```
+
+2. SecretStore の疎通を確認:
+
+```bash
+kubectl get clustersecretstore postal-converter-ja-prod
+kubectl -n external-secrets get pods
+```
+
+3. Helm values の参照先キーを確認:
+
+```bash
+grep -n "externalSecret:" deploy/helm/postal-converter-ja/values-prod.yaml
+```
+
+4. Helm apply（ExternalSecret 有効）:
+
+```bash
+helm upgrade --install postal-converter-ja deploy/helm/postal-converter-ja \
+  -n postal-converter-ja-prod \
+  --create-namespace \
+  -f deploy/helm/postal-converter-ja/values.yaml \
+  -f deploy/helm/postal-converter-ja/values-prod.yaml
+```
+
+5. 同期確認:
+
+```bash
+kubectl -n postal-converter-ja-prod get externalsecret
+kubectl -n postal-converter-ja-prod describe externalsecret postal-converter-ja-external-secret
+kubectl -n postal-converter-ja-prod get secret postal-converter-ja-secret -o jsonpath='{.data}' | jq
+```
+
+6. アプリ確認:
+
+```bash
+kubectl -n postal-converter-ja-prod rollout status deploy/postal-converter-ja
+kubectl -n postal-converter-ja-prod port-forward svc/postal-converter-ja 3202:3202
+curl -fsS http://127.0.0.1:3202/ready
+```
+
+## 3. 障害時の一次確認
+
+### Case A: ExternalSecret が `Ready=False`
+
+確認:
+
+```bash
+kubectl -n postal-converter-ja-prod describe externalsecret postal-converter-ja-external-secret
+kubectl -n external-secrets logs deploy/external-secrets -f --tail=200
+```
+
+見るべき点:
+
+- `ClusterSecretStore not found`
+- remote key / property の typo
+- 認証エラー（cloud IAM / service account）
+
+### Case B: `postal-converter-ja-secret` が未作成 or キー不足
+
+確認:
+
+```bash
+kubectl -n postal-converter-ja-prod get secret postal-converter-ja-secret -o yaml
+```
+
+見るべき点:
+
+- `POSTGRES_DATABASE_URL`
+- `MYSQL_DATABASE_URL`
+- `SQLITE_DATABASE_PATH`
+- `REDIS_URL`
+
+### Case C: API が Ready にならない
+
+確認:
+
+```bash
+kubectl -n postal-converter-ja-prod logs deploy/postal-converter-ja --tail=200
+kubectl -n postal-converter-ja-prod get events --sort-by=.lastTimestamp | tail -n 30
+```
+
+見るべき点:
+
+- DB URL 形式不正
+- Redis 到達不可（`READY_REQUIRE_CACHE=true` の場合）
+- Secret 更新後に Pod が古い環境変数を保持しているケース
+
+必要に応じて再起動:
+
+```bash
+kubectl -n postal-converter-ja-prod rollout restart deploy/postal-converter-ja
+kubectl -n postal-converter-ja-prod rollout status deploy/postal-converter-ja
+```
+
+## 4. 緊急ロールバック
+
+1. 直前リリースへ戻す:
+
+```bash
+helm -n postal-converter-ja-prod history postal-converter-ja
+helm -n postal-converter-ja-prod rollback postal-converter-ja <REVISION>
+```
+
+2. Secret が壊れている場合は退避済み Secret を復元:
+
+```bash
+kubectl apply -f /tmp/postal-converter-ja-secret.backup.yaml
+kubectl -n postal-converter-ja-prod rollout restart deploy/postal-converter-ja
+```
+
+3. 復旧後、`values-*.yaml` と SecretManager 側の key/property を見直して再実施する。

--- a/docs/K8S_ADOPTION_BLUEPRINT.md
+++ b/docs/K8S_ADOPTION_BLUEPRINT.md
@@ -127,6 +127,11 @@ helm template postal-converter-ja deploy/helm/postal-converter-ja \
 kubeconform -strict -summary -ignore-missing-schemas /tmp/postal-rendered.yaml
 ```
 
+補足:
+
+- CRD（例: `ExternalSecret`）は kubeconform のデフォルトスキーマ対象外のため、CI では `-ignore-missing-schemas` を利用します。
+- 許容方針と見直し条件は `docs/CI_DESIGN.md` に明文化します。
+
 ### Step 4: デプロイ
 
 ```bash

--- a/docs/KUBERNETES_DEPLOYMENT.md
+++ b/docs/KUBERNETES_DEPLOYMENT.md
@@ -77,3 +77,5 @@ argocd app wait postal-converter-ja-prod --health --operation
 - `secret.create=false` を維持し、接続情報は External Secrets 側で管理してください。
 - `ingress.enabled` / `networkPolicy.enabled` は環境 values で明示的に有効化してください。
 - `image.repository` / `image.tag` は CI 生成イメージに合わせて固定してください。
+- External Secrets の切替・障害時確認は `docs/EXTERNAL_SECRETS_RUNBOOK.md` を参照してください。
+- CI の kubeconform では CRD（例: `ExternalSecret`）に対して `-ignore-missing-schemas` を使用します。詳細方針は `docs/CI_DESIGN.md` を参照してください。

--- a/docs/OPERATIONS_RUNBOOK_v0.9.md
+++ b/docs/OPERATIONS_RUNBOOK_v0.9.md
@@ -1,0 +1,86 @@
+# Operations Runbook Draft for v0.9
+
+このドキュメントは v0.9 で整備する運用 Runbook の初版ドラフトです。
+
+## 1. SLI / SLO（初期案）
+
+対象サービス: `postal_converter_ja` API
+
+### Availability
+
+- SLI: `/ready` が 2xx を返した割合
+- SLO: 月次 99.9% 以上
+- Error budget: 43m 49s / 30日
+
+### Latency
+
+- SLI: `GET /postal_codes/*` の p95
+- SLO: p95 < 300ms（5分窓）
+
+### Correctness / Error Rate
+
+- SLI: 5xx 比率（`errors_total / requests_total`）
+- SLO: 5xx 比率 < 1.0%（5分平均）
+
+### Freshness（バッチ連携）
+
+- SLI: 郵便番号更新ジョブ最終成功からの経過時間
+- SLO: 24時間以内に最新成功が1回以上
+
+## 2. 監視ダッシュボード最低要件
+
+- `requests_total`
+- `errors_total`
+- `not_found_total`
+- `average_latency_ms`
+- `/ready` の HTTP ステータス
+- DB / Redis 接続エラー件数（ログベース）
+
+## 3. 一次対応フロー（15分）
+
+1. 事象分類:
+   - 5xx 増加
+   - Ready 失敗継続
+   - 高レイテンシ
+   - データ更新停止
+2. 影響範囲の確認:
+   - `dev/stg/prod` のどの環境か
+   - 単一 Pod か全 Pod か
+3. 即時コマンド:
+
+```bash
+kubectl -n postal-converter-ja-prod get deploy,po,svc,ingress,externalsecret
+kubectl -n postal-converter-ja-prod get events --sort-by=.lastTimestamp | tail -n 30
+kubectl -n postal-converter-ja-prod logs deploy/postal-converter-ja --tail=200
+curl -fsS https://<prod-host>/ready
+```
+
+4. 判定:
+   - Secret/接続起因なら `EXTERNAL_SECRETS_RUNBOOK.md` に沿って切り分け
+   - リリース起因なら Helm rollback を優先
+   - インフラ起因（LB/Ingress/DB 障害）なら platform 担当へ即時エスカレーション
+
+## 4. エスカレーション基準
+
+- 10分以上 `ready` 失敗継続
+- 5xx 比率が 5分平均で 3% 超
+- 主要機能（郵便番号検索）が実質利用不能
+
+上記のいずれかを満たした場合:
+
+- Incident チャンネルに告知
+- On-call / platform 担当に連絡
+- 暫定対処（rollback or traffic drain）を先行
+
+## 5. 復旧後の必須アクション
+
+- 障害タイムライン作成（検知時刻、一次対応、復旧時刻）
+- 再発防止タスクを issue 化
+- SLO 逸脱時は error budget 消費を記録
+- 必要なら SLI 定義・アラート閾値を更新
+
+## 6. v0.9 で確定させる項目
+
+- SLI 計測基盤（Prometheus/Grafana か他基盤か）
+- オンコール体制（担当ローテーション、連絡経路）
+- Runbook の自動化（診断コマンド集約、復旧手順の半自動化）

--- a/docs/OPERATIONS_RUNBOOK_v0.9.md
+++ b/docs/OPERATIONS_RUNBOOK_v0.9.md
@@ -10,7 +10,7 @@
 
 - SLI: `/ready` が 2xx を返した割合
 - SLO: 月次 99.9% 以上
-- Error budget: 43m 49s / 30日
+- Error budget: 43m 12s / 30日
 
 ### Latency
 

--- a/docs/OPERATIONS_RUNBOOK_v0.9.md
+++ b/docs/OPERATIONS_RUNBOOK_v0.9.md
@@ -56,7 +56,7 @@ curl -fsS https://<prod-host>/ready
 ```
 
 4. 判定:
-   - Secret/接続起因なら `EXTERNAL_SECRETS_RUNBOOK.md` に沿って切り分け
+   - Secret/接続起因なら `docs/EXTERNAL_SECRETS_RUNBOOK.md` に沿って切り分け
    - リリース起因なら Helm rollback を優先
    - インフラ起因（LB/Ingress/DB 障害）なら platform 担当へ即時エスカレーション
 


### PR DESCRIPTION
## 概要 (Description)

v0.8.4 の合意タスク（1〜6）を `feature/v8.4.0` で実施しました。

- PR #82 を先に `main` へ取り込み、その内容を `feature/v8.4.0` に同期
- Kubernetes docs を v0.8.3 最終状態ベースで整理し、Runbook 導線を追加
- External Secrets 最小運用 Runbook を追加
- CI の kubeconform 検証を CRD 方針が明確な形に整理
- v0.9 準備として SLO/SLI・一次対応中心の運用 Runbook ドラフトを追加

## 変更の種類 (Type of change)

- [ ] バグ修正 (既存機能の修正・破壊的変更なし)
- [ ] 新機能追加 (既存機能への追加・破壊的変更なし)
- [ ] 破壊的変更 (既存機能が期待通り動作しなくなる修正・機能追加)
- [x] ドキュメント更新

## チェックリスト (Checklist)

- [x] プロジェクトのスタイルガイドに従っている
- [x] 自分のコードをセルフレビューした
- [x] 理解しにくい箇所にはコメントを追加した
- [x] 関連するドキュメントを変更した
- [x] 新たな警告 (Warning) が発生していない
- [ ] 修正の有効性や機能の動作を証明するテストを追加した
- [x] 新規および既存の単体テストがローカルでパスしている

## 主要変更ファイル

- `.github/workflows/ci.yml`
- `README.md`
- `docs/CI_DESIGN.md`
- `docs/KUBERNETES_DEPLOYMENT.md`
- `docs/K8S_ADOPTION_BLUEPRINT.md`
- `docs/EXTERNAL_SECRETS_RUNBOOK.md` (new)
- `docs/OPERATIONS_RUNBOOK_v0.9.md` (new)

## 検証

- `helm lint deploy/helm/postal-converter-ja`
- `helm template` (default/dev/stg/prod)
- `kubeconform -strict -summary -ignore-missing-schemas` (rendered manifests)
