### PR TITLE
v0.9.0.1: release整合とQA人間タスクのv0.9.2移管

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,14 +348,14 @@ Terraform 関連の実行コマンド:
 ```bash
 ./scripts/setup_github_oidc_vars.sh
 ./scripts/run_terraform_workflow.sh
-./scripts/run_terraform_workflow.sh --action destroy --environment dev --confirm-destroy DESTROY_AWS --ref feature/v0.8.0
+./scripts/run_terraform_workflow.sh --action destroy --environment dev --confirm-destroy DESTROY_AWS --ref v0.9.0
 nix develop --command terraform version
 ```
 
 `terraform` がローカルシェルで見えない場合は Nix dev shell 経由で実行してください（Nix では OpenTofu 互換の `terraform` コマンドを提供）。  
 Homebrew 経由では `terraform` が 1.5.7 固定になることがあるため、バージョン差異を避ける目的でも Nix を推奨します。
 
-Terraform/OpenTofu バージョン方針（v0.8）:
+Terraform/OpenTofu バージョン方針（v0.9）:
 
 - 最小要件: `>= 1.6.0`（`infra/terraform/platforms/aws/main.tf`）
 - CI 固定: `1.11.1`（`.github/workflows/terraform-multiplatform.yml`）
@@ -372,23 +372,22 @@ CI でも同等チェック（fmt/validate）を実行します。
 
 👉 **SQLite 配布ワークフロー（GitHub Actions 手動実行）:** `.github/workflows/sqlite-release.yml`
 
-
 ## ライセンスと商用利用について
 
 本プロジェクトは、**デュアルライセンス**（Dual Licensing）を採用する予定です。
 
-1.  **個人利用・非営利・オープンソース開発**:
+1. **個人利用・非営利・オープンソース開発**:
 
     - **MIT License** の下、自由に利用・改変・再配布が可能です。
     - 学習目的や個人プロジェクトでぜひご活用ください。
 
-2.  **法人利用・商用サービスへの組み込み**:
+2. **法人利用・商用サービスへの組み込み**:
     - 企業での業務利用や、商用製品への組み込みを行う場合は、**商用ライセンス**の契約、または**GitHub Sponsors**等による継続的な支援をお願いすることを想定しています。
     - （現在はプレビュー版のため、評価目的での利用は無償です。本格導入の際はご連絡ください）
 
 このモデルにより、オープンソースとしての発展と、持続可能な開発体制の両立を目指しています。
 
-## ロードマップ (TODO)
+## ロードマップ
 
 実行順序とマイルストーンは `docs/V0_7_TO_V1_EXECUTION_PLAN.md` を参照してください。
 
@@ -401,7 +400,14 @@ CI でも同等チェック（fmt/validate）を実行します。
 - [ ] **Kubernetes 連携**: コンテナ連携・オーケストレーション対応（Helm/Kustomize/ArgoCD 含む）
 - [x] **API ドキュメントの拡充**: Swagger/OpenAPI による仕様書生成
 
-### v0.8.x フォーカス（デプロイ基盤の仕上げ）
+### v0.9.1 フォーカス（非人間修正・整頓）
+
+- [x] **v0.9.0 Release整合**: `v0.9.0` タグ範囲に合わせてリリースノートを更新（`#84`-`#91`）
+- [x] **README整備**: 古い参照更新（`--ref v0.9.0`）と Markdown lint 指摘の解消
+- [ ] **Docs棚卸し**: 不要DOCの削除候補と `.gitignore` 化方針を整理
+- [ ] **複雑度の高い箇所の改修**: 複雑度 15 超を対象に段階的リファクタ
+
+### v0.8.x 実績（デプロイ基盤）
 
 - [x] **AWS先行IaC運用**: GitHub Actions + Terraform の `validate/plan/apply/destroy` を `dev` で実行可能化
 - [x] **環境分離**: `dev/stg/prod` の `aws.tfvars` を追加
@@ -412,7 +418,7 @@ CI でも同等チェック（fmt/validate）を実行します。
 
 ## バージョン
 
-**v0.8.0 (Beta)** - Deployment baseline with AWS-first Terraform workflow
+**v0.9.0 (Beta)** - Operations readiness package and launcher UX hardening
 
 ## 貢献について (Contributing)
 

--- a/docs/V0_9_0_ACCEPTANCE.md
+++ b/docs/V0_9_0_ACCEPTANCE.md
@@ -1,0 +1,45 @@
+# v0.9.0 Acceptance (for QA-04 in v0.9.2)
+
+最終更新: 2026-02-16 (JST)  
+ステータス: `PENDING (Human tasks in v0.9.2)`
+
+## 1. 判定対象
+
+- `QA-02`: 人間テスト（ドライラン）
+- `QA-03`: Runbook 改訂
+- `QA-04`: 最終受け入れ（Go/No-Go）
+
+根拠ドキュメント:
+- `docs/V0_9_0_RUNBOOK_EXECUTION_PLAN.md`
+- `docs/HUMAN_TEST_SCENARIO_v0_9_0.md`
+
+## 2. Exit Criteria チェック
+
+- [ ] 疑似障害 3種を Runbook のみで処理可能
+- [ ] 月次監査レポートを定義入力から生成可能
+- [ ] 営業 -> 導入 -> 運用引き継ぎがテンプレートで再現可能
+- [ ] 仕様書/運用書/販売資料で用語不一致がない
+
+## 3. 実施ログ（QA-02）
+
+| 項目 | 記録 |
+| --- | --- |
+| 実施日 | TBA |
+| 実施者 | TBA |
+| シナリオ | HT-01 / HT-02 / HT-03 / HT-04 / HT-05 |
+| 結果 | TBA |
+| 詰まりポイント | TBA |
+| 改善チケット | TBA |
+
+## 4. Runbook 改訂差分（QA-03）
+
+- 改訂対象: TBA
+- 変更理由: TBA
+- 変更リンク: TBA
+
+## 5. 最終判定（QA-04）
+
+- 判定: `GO / NO-GO` (TBA)
+- 判定日: TBA
+- 判定者: TBA
+- コメント: TBA

--- a/docs/V0_9_0_RELEASE_NOTES.md
+++ b/docs/V0_9_0_RELEASE_NOTES.md
@@ -1,0 +1,79 @@
+# v0.9.0 Release Notes
+
+## 日本語
+
+### タイトル
+`v0.9.0 (Beta) - 運用準備パッケージとランチャーUX強化`
+
+### 本文
+`v0.8.0` から `v0.9.0` では、運用準備とオペレーター体験を中心に改善しました。  
+比較範囲: `v0.8.0...v0.9.0`（53 commits / 64 files changed）
+
+主な差分:
+- 運用標準の追加
+  - v0.9.0 実行計画、運用Runbook（更新失敗 / キャッシュ障害 / DBロールバック）
+  - SLO/SLI、アラートポリシー、ダッシュボード標準
+  - 月次監査、NDAオンボーディング、見積テンプレート
+  - Human test シナリオ、v0.9タスク用 Issue Template
+- ランチャーの運用UXと信頼性を改善
+  - API/Frontend を管理プロセスとして起動し、PID復旧と Ctrl+C 復帰を強化
+  - 起動完了判定に readiness チェックを導入
+  - マウスクリック操作、URL/ログ表示、ローディング視認性を改善
+- フロントエンドの郵便番号検索を修正
+  - Postal SDK の `fetch Illegal invocation` 問題を修正
+- デプロイ基盤を強化
+  - Helm-first 構成、ArgoCD環境分離（dev/stg/prod）、Ingress/NetworkPolicy、External Secrets 雛形
+  - CI に Helm lint/template と kubeconform 検証を追加
+- 依存関係アップデート（v0.9.0タグ取り込み分）
+  - frontend: `@typescript-eslint/parser`, `framer-motion`, `styled-components`
+  - worker/api: `redis`, `rusqlite`
+  - worker/crawler: `redis`, `zip`
+  - GitHub Actions: `dtolnay/rust-toolchain`
+
+互換性:
+- APIコントラクトの破壊的変更はありません。
+- 主な変更はドキュメント追加と運用/UX改善です。
+
+関連PR:
+- `#94` v0.9.0 operations readiness package and launcher UX hardening
+- `#84` - `#91` dependabot updates merged into v0.9.0
+
+---
+
+## English
+
+### Title
+`v0.9.0 (Beta) - Operations Readiness Package and Launcher UX Hardening`
+
+### Body
+From `v0.8.0` to `v0.9.0`, this release focuses on operational readiness and operator experience.  
+Comparison range: `v0.8.0...v0.9.0` (53 commits / 64 files changed)
+
+Key changes:
+- Added operational standards and readiness assets
+  - v0.9.0 execution plan and runbooks (update failure / cache incident / DB rollback)
+  - SLO/SLI, alert policy, and dashboard standards
+  - Monthly audit, NDA onboarding, and estimation templates
+  - Human test scenario and v0.9 task issue template
+- Improved launcher UX and reliability
+  - Managed API/frontend processes with PID recovery and safer Ctrl+C behavior
+  - Readiness checks before marking services as started
+  - Mouse-click actions, clearer URL/log guidance, and better loading visibility
+- Fixed frontend postal lookup behavior
+  - Resolved Postal SDK `fetch Illegal invocation`
+- Strengthened deployment baseline
+  - Helm-first structure, ArgoCD env split (dev/stg/prod), ingress/network policy, External Secrets skeleton
+  - Added Helm lint/template and kubeconform validation in CI
+- Dependency updates included in v0.9.0 tag
+  - frontend: `@typescript-eslint/parser`, `framer-motion`, `styled-components`
+  - worker/api: `redis`, `rusqlite`
+  - worker/crawler: `redis`, `zip`
+  - GitHub Actions: `dtolnay/rust-toolchain`
+
+Compatibility:
+- No breaking API contract changes.
+- Most changes are additive docs plus operations/UX hardening.
+
+Related PRs:
+- `#94` v0.9.0 operations readiness package and launcher UX hardening
+- `#84` - `#91` dependabot updates merged into v0.9.0

--- a/docs/V0_9_0_RUNBOOK_EXECUTION_PLAN.md
+++ b/docs/V0_9_0_RUNBOOK_EXECUTION_PLAN.md
@@ -1,6 +1,6 @@
 # v0.9.0 Runbook 着手計画 (`feature/v0.9.0`)
 
-最終更新: 2026-02-14 (JST)  
+最終更新: 2026-02-16 (JST)  
 目的: `v0.9.0` を「運用で回せる状態」まで最短で持っていくための、実行順序固定の計画書。
 
 ## 0. 取り込み元 (v0.9 要件の統合)
@@ -60,9 +60,9 @@
 | BIZ-01 | Sales Ops | 契約/NDA 導入チェック化 | `docs/NDA_ONBOARDING_CHECKLIST_v0_9_0.md` | - | 営業->導入引き継ぎ時の確認漏れが0 |
 | BIZ-02 | Sales Ops | 顧客別導入テンプレ・見積基準 | `docs/CUSTOMER_ONBOARDING_ESTIMATE_TEMPLATE_v0_9_0.md` | BIZ-01 | 工数見積の入力項目と判定ルールが固定 |
 | QA-01 | Human Test | 障害訓練シナリオ作成 | `docs/HUMAN_TEST_SCENARIO_v0_9_0.md` | RNB-01..03 | 3障害 + 1監査生成の訓練脚本が完成 |
-| QA-02 | Human Test | 人間テスト1回目 (ドライラン) | 証跡ログ/改善チケット | QA-01 | 手順詰まりポイントが記録されている |
-| QA-03 | Human Test | Runbook 改訂 | Runbook v2 | QA-02 | 改訂差分と理由が残っている |
-| QA-04 | Human Test | 最終受け入れ (Go/No-Go) | `docs/V0_9_0_ACCEPTANCE.md` | QA-03, AUD-01, BIZ-02 | Exit Criteriaを満たす判定結果がある |
+| QA-02 | Human Test | 人間テスト1回目 (ドライラン, v0.9.2へ移管) | 証跡ログ/改善チケット | QA-01 | 手順詰まりポイントが記録されている |
+| QA-03 | Human Test | Runbook 改訂 (v0.9.2へ移管) | Runbook v2 | QA-02 | 改訂差分と理由が残っている |
+| QA-04 | Human Test | 最終受け入れ (Go/No-Go, v0.9.2へ移管) | `docs/V0_9_0_ACCEPTANCE.md` | QA-03, AUD-01, BIZ-02 | Exit Criteriaを満たす判定結果がある |
 
 ## 4. 人間テスト計画 (必須)
 
@@ -132,3 +132,10 @@
 - 2026-02-14: `BIZ-01` の成果物として `docs/NDA_ONBOARDING_CHECKLIST_v0_9_0.md` を作成。
 - 2026-02-14: `BIZ-02` の成果物として `docs/CUSTOMER_ONBOARDING_ESTIMATE_TEMPLATE_v0_9_0.md` を作成。
 - 2026-02-14: `QA-01` の成果物として `docs/HUMAN_TEST_SCENARIO_v0_9_0.md` を作成。
+- 2026-02-16: `QA-02`, `QA-03`, `QA-04` は人間実施が前提のため `v0.9.2` へ繰り越し決定。
+
+## 10. v0.9.2 へ繰り越し (Human Tasks)
+
+- `QA-02`: 人間テスト（ドライラン）を実施し、詰まりポイントを証跡化。
+- `QA-03`: `QA-02` の結果を反映して Runbook を改訂。
+- `QA-04`: 最終受け入れ判定を行い、`docs/V0_9_0_ACCEPTANCE.md` を完成させる。


### PR DESCRIPTION
## Summary
v0.9.0 周辺のドキュメント整合を `main` とタグ実体に合わせて修正し、
人間タスク (`QA-02/03/04`) を `v0.9.2` に繰り越す方針を明文化しました。

### What changed
- `docs/V0_9_0_RELEASE_NOTES.md`
  - `v0.9.0` タグ範囲に合わせて依存更新の記載を補正
  - Related PR を `#84`-`#91` に補正
- `README.md`
  - 古い `--ref feature/v0.8.0` を `--ref v0.9.0` に更新
  - バージョン表記を `v0.9.0 (Beta)` に更新
  - Markdown lint 指摘（空行/リストマーカー空白）を修正
  - `v0.9.1` フォーカス節を追加（非人間修正タスク明示）
- `docs/V0_9_0_RUNBOOK_EXECUTION_PLAN.md`
  - `QA-02/03/04` を `v0.9.2` へ移管する旨を明記
- `docs/V0_9_0_ACCEPTANCE.md`
  - `QA-04` 用の受け入れ判定テンプレートを新規追加

## Why
- 公開済み `v0.9.0` Release 本文とタグ実体の不一致を解消するため
- `v0.9.1` を非人間修正に集中させ、
  人間実施が必要な QA は `v0.9.2` へ明確に切り分けるため

## Scope
- docs / README のみ（アプリ実装変更なし）

## Follow-up
- `feature/v0.9.1`: Docs棚卸し、複雑度15超の改修
- `v0.9.2`: QA-02, QA-03, QA-04（人間テスト/Runbook改訂/最終受け入れ）
