### PR TITLE
bugfix/0.9.1: fix CI rust toolchain install failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
       # Rust toolchain
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
 
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
 

--- a/.github/workflows/sqlite-release.yml
+++ b/.github/workflows/sqlite-release.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install SQLite CLI
         run: |


### PR DESCRIPTION
## Summary
Fix CI failures caused by an invalid Rust toolchain version reference in GitHub Actions.

## Root cause
`dtolnay/rust-toolchain@1.100.0` resolved to Rust `1.100.0`, which does not exist, causing `Install Rust` to fail with HTTP 404.

## Changes
- `.github/workflows/ci.yml`
  - `dtolnay/rust-toolchain@1.100.0` -> `dtolnay/rust-toolchain@stable` (2 places)
- `.github/workflows/sqlite-release.yml`
  - `dtolnay/rust-toolchain@1.100.0` -> `dtolnay/rust-toolchain@stable`

## Expected result
- `CI / Rust API & Crawler Build / Test` passes install step
- `CI / DB Integration Test (MySQL + PostgreSQL)` passes install step

## Note
No application code changes. Workflow-only fix.
