### PR TITLE
fix: onboard script compatibility and nix detection

### DIFF
--- a/scripts/setup_nix_docker.sh
+++ b/scripts/setup_nix_docker.sh
@@ -60,11 +60,22 @@ install_on_macos() {
 }
 
 source_nix_if_available() {
-  if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+  local nix_profile_script="/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
+  local nix_profile_bin="/nix/var/nix/profiles/default/bin"
+
+  if [ -f "${nix_profile_script}" ]; then
     # shellcheck disable=SC1091
-    source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+    source "${nix_profile_script}"
+  fi
+
+  if ! require_in_path nix && [ -x "${nix_profile_bin}/nix" ]; then
+    export PATH="${nix_profile_bin}:$PATH"
+  fi
+
+  if require_in_path nix; then
     return 0
   fi
+
   return 1
 }
 


### PR DESCRIPTION
## Summary
- remove docker compose profile flag usage in onboard flow for broader compose compatibility
- make nix detection robust by sourcing nix-daemon and falling back to /nix profile bin PATH
- allow ./scripts/onboard.sh --stop to work without requiring nix
- add explicit port-in-use checks for API(3202)/Frontend(3203)

## Verification
- bash -n scripts/onboard.sh
- bash -n scripts/setup_nix_docker.sh
- local run: source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh && ./scripts/onboard.sh --profile dev
- local run: ./scripts/onboard.sh --stop