### PR TITLE
fix: make onboard resilient to compose command differences

### DIFF
--- a/scripts/setup_nix_docker.sh
+++ b/scripts/setup_nix_docker.sh
@@ -99,6 +99,22 @@ ensure_docker_daemon() {
   exit 1
 }
 
+ensure_compose_command() {
+  if docker compose version >/dev/null 2>&1; then
+    log "Docker Compose is available via: docker compose"
+    return 0
+  fi
+
+  if require_in_path docker-compose; then
+    log "Docker Compose is available via: docker-compose"
+    return 0
+  fi
+
+  echo "Docker Compose command is not available."
+  echo "Install Docker Compose plugin or docker-compose, then retry."
+  exit 1
+}
+
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --profile)
@@ -168,6 +184,7 @@ require_in_path docker || {
 }
 
 ensure_docker_daemon
+ensure_compose_command
 
 log "Preparing project files..."
 mkdir -p "${ROOT_DIR}/storage/mysql/mysql_data" \


### PR DESCRIPTION
## Summary
- add compose runner detection in onboarding (`docker compose` first, fallback to `docker-compose`)
- route all compose calls through the detected runner
- add compose availability check in setup script for early failure with clear guidance

## Why
Some environments report errors like `unknown shorthand flag: 'd' in -d` for `docker compose up -d ...`, despite Docker being installed. This makes onboarding fail on certain machines.

## Verification
- bash -n scripts/onboard.sh
- bash -n scripts/setup_nix_docker.sh
- ./scripts/onboard.sh --profile dev
- ./scripts/onboard.sh --stop
