### PR TITLE
fix: harden docker compose detection for MacBook env

### DIFF
--- a/scripts/onboard.sh
+++ b/scripts/onboard.sh
@@ -37,7 +37,11 @@ require_command() {
 }
 
 init_compose_driver() {
-  if docker compose version >/dev/null 2>&1; then
+  local compose_version_output
+
+  if compose_version_output="$(docker compose version 2>&1)" \
+    && ! printf '%s' "${compose_version_output}" | grep -q "^Docker version " \
+    && docker compose up --help >/dev/null 2>&1; then
     COMPOSE_DRIVER="docker compose"
     return 0
   fi

--- a/scripts/setup_nix_docker.sh
+++ b/scripts/setup_nix_docker.sh
@@ -100,7 +100,11 @@ ensure_docker_daemon() {
 }
 
 ensure_compose_command() {
-  if docker compose version >/dev/null 2>&1; then
+  local compose_version_output
+
+  if compose_version_output="$(docker compose version 2>&1)" \
+    && ! printf '%s' "${compose_version_output}" | grep -q "^Docker version " \
+    && docker compose up --help >/dev/null 2>&1; then
     log "Docker Compose is available via: docker compose"
     return 0
   fi


### PR DESCRIPTION
## Summary
- tighten compose v2 detection in onboard/setup scripts
- reject false-positive `docker compose version` responses that actually return `Docker version ...`
- require `docker compose up --help` to succeed before selecting compose v2

## Why
On one MacBook, `docker compose -v` resolved to Docker CLI version output and `docker compose up -d ...` failed with `unknown shorthand flag: 'd' in -d`.
This change prevents selecting a broken compose v2 path and falls back to `docker-compose` when available.

## Verification
- bash -n scripts/onboard.sh
- bash -n scripts/setup_nix_docker.sh
- ./scripts/onboard.sh --stop
