### PR TITLE
chore(deps): align react-dom with react

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "lucide-react": "^1.8.0",
     "next": "latest",
     "react": "^19.2.5",
-    "react-dom": "^19.2.4",
+    "react-dom": "^19.2.5",
     "styled-components": "^6.4.0",
     "tailwind-merge": "^3.5.0",
     "zod": "^3.23.8"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3702,10 +3702,10 @@ radix-ui@^1.1.3:
     "@radix-ui/react-use-size" "1.1.1"
     "@radix-ui/react-visually-hidden" "1.2.3"
 
-react-dom@^19.2.4:
-  version "19.2.4"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.4.tgz#6fac6bd96f7db477d966c7ec17c1a2b1ad8e6591"
-  integrity sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==
+react-dom@^19.2.5:
+  version "19.2.5"
+  resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz#b8768b10837d0b8e9ca5b9e2d58dff3d880ea25e"
+  integrity sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==
   dependencies:
     scheduler "^0.27.0"
 


### PR DESCRIPTION
## Summary
- Update frontend react-dom from ^19.2.4 to ^19.2.5
- Keep React and React DOM on the same 19.2.5 patch level

## Validation
- yarn install --frozen-lockfile
- yarn lint
- yarn build