### PR TITLE
feat(frontend): publish GitHub Pages example

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+github: [mt4110]
+custom:
+  - https://github.com/mt4110/postal_converter_ja/blob/main/SPONSORS.md

--- a/.github/workflows/frontend-pages.yml
+++ b/.github/workflows/frontend-pages.yml
@@ -1,0 +1,70 @@
+name: Frontend Pages
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-pages.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build GitHub Pages artifact
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+          cache-dependency-path: frontend/yarn.lock
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: yarn install --frozen-lockfile
+
+      - name: Build static frontend
+        working-directory: frontend
+        env:
+          GITHUB_PAGES_REPOSITORY_NAME: postal_converter_ja
+        run: yarn build:pages
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: frontend/out
+
+  deploy:
+    name: Deploy GitHub Pages
+    if: github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ docs/*_LOCAL.md
 
 # local recovery / tooling artifacts
 .git.broken_*
+.codex/
 .trunk/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 ![Version](https://img.shields.io/badge/version-0.8.0-blue.svg)
 ![Status](https://img.shields.io/badge/status-beta-orange.svg)
 
+Example Demo: [GitHub Pages](https://mt4110.github.io/postal_converter_ja/) / Support: [SPONSORS.md](./SPONSORS.md) / Plan: [V0_7_TO_V1_EXECUTION_PLAN.md](./docs/V0_7_TO_V1_EXECUTION_PLAN.md)
+
 English README: [ENGLISH_README.md](./docs/ENGLISH_README.md)
 
 このプロジェクトは、日本郵便のデータを自動的に取得・更新し、常に最新の郵便番号データを提供するシステムです。
@@ -72,7 +74,9 @@ nix develop --command go build -o postal-launcher
 ## 📹 クイックスタート (Launcher) demo映像
 
 <!-- markdownlint-disable MD033 -->
+
 <video src="https://github.com/mt4110/postal_converter_ja/releases/download/v0.9.0/2026-02-26_11-33-48.mp4" controls width="800"></video>
+
 <!-- markdownlint-enable MD033 -->
 
 ---
@@ -295,6 +299,17 @@ nix develop --command bash -lc "cd frontend && yarn install && yarn dev"
 
 SDK 実装サンプルは `frontend/src/lib/postal-sdk.ts` を参照してください。
 
+### GitHub Pages Example
+
+フロントエンドのサンプルは、GitHub Pages 向けに静的 export できます。
+
+- Demo URL: `https://mt4110.github.io/postal_converter_ja/`
+- Pages 用ビルド: `cd frontend && yarn build:pages`
+- Pages 版は `NEXT_PUBLIC_DEMO_MODE=true` でビルドし、公開APIなしでも操作感を確認できるデモデータを使います。
+- 実APIに接続する場合は、ローカル実行または公開済みAPIの `NEXT_PUBLIC_API_URL` を指定してください。
+
+初回公開時は、GitHub の `Settings > Pages` で Source を `GitHub Actions` に設定してから、`Frontend Pages` workflow を手動実行してください。これはリポジトリの admin / maintainer 権限が必要な操作です。
+
 ## トラブルシューティング
 
 👉 **トラブルシューティングについてはこちら:** [TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md)
@@ -383,13 +398,12 @@ CI でも同等チェック（fmt/validate）を実行します。
 本プロジェクトは、**デュアルライセンス**（Dual Licensing）を採用する予定です。
 
 1. **個人利用・非営利・オープンソース開発**:
-
-    - **MIT License** の下、自由に利用・改変・再配布が可能です。
-    - 学習目的や個人プロジェクトでぜひご活用ください。
+   - **MIT License** の下、自由に利用・改変・再配布が可能です。
+   - 学習目的や個人プロジェクトでぜひご活用ください。
 
 2. **法人利用・商用サービスへの組み込み**:
-    - 企業での業務利用や、商用製品への組み込みを行う場合は、**商用ライセンス**の契約、または**GitHub Sponsors**等による継続的な支援をお願いすることを想定しています。
-    - （現在はプレビュー版のため、評価目的での利用は無償です。本格導入の際はご連絡ください）
+   - 企業での業務利用や、商用製品への組み込みを行う場合は、**商用ライセンス**の契約、または**GitHub Sponsors**等による継続的な支援をお願いすることを想定しています。
+   - （現在はプレビュー版のため、評価目的での利用は無償です。本格導入の際はご連絡ください）
 
 このモデルにより、オープンソースとしての発展と、持続可能な開発体制の両立を目指しています。
 
@@ -400,10 +414,10 @@ CI でも同等チェック（fmt/validate）を実行します。
 - [x] **CI/CD パイプラインの構築**: GitHub Actions による自動テスト・ビルド
 - [x] **ランチャーの UX 改善**: 実行順序の制御と視覚的フィードバック
 - [x] **環境構築の自動化 (v0.6)**: `scripts/setup_nix_docker.sh` + `scripts/onboard.sh` で導入を標準化
-- [ ] **マルチプラットフォーム デプロイ基盤**: GitHub Actions + Terraform による環境展開（クラウド別ターゲット対応）
+- [x] **マルチプラットフォーム デプロイ基盤（骨格）**: GitHub Actions + Terraform による環境展開（AWS先行、GCP/Azureターゲット雛形）
 - [x] **MySQL/PostgreSQL の自動テスト**: 両 DB でのインテグレーションテスト追加
 - [x] **Docker イメージの軽量化**: マルチステージビルドの最適化（API/Crawler）
-- [ ] **Kubernetes 連携**: コンテナ連携・オーケストレーション対応（Helm/Kustomize/ArgoCD 含む）
+- [x] **Kubernetes 連携（最小構成）**: コンテナ連携・オーケストレーション対応（Helm/Kustomize/ArgoCD 含む）
 - [x] **API ドキュメントの拡充**: Swagger/OpenAPI による仕様書生成
 
 ### v0.9.1 フォーカス（非人間修正・整頓）
@@ -421,6 +435,13 @@ CI でも同等チェック（fmt/validate）を実行します。
 - [x] **ロールバック運用**: `destroy` 手順を runbook 化し、実行証跡を追加
 - [ ] **マルチクラウド再拡張**: GCP/Azure ターゲットの再導入
 - [x] **Kubernetes最小構成**: Helm/Kustomize/ArgoCD 雛形の追加（`deploy/helm/postal-converter-ja`, `deploy/k8s/base`, `deploy/argocd`）
+
+### 人間の認証・アカウント操作が必要な残タスク
+
+- GitHub Pages の初回有効化: `Settings > Pages` で Source を `GitHub Actions` に設定
+- GitHub Sponsors の有効化: `mt4110` アカウント側で Sponsors profile を有効化
+- Terraform apply / destroy: AWS/GCP/Azure の実アカウント、OIDC Role、GitHub Secrets/Variables の設定
+- v0.9.2 Human QA: `docs/V0_9_0_ACCEPTANCE.md` に沿った人間の操作確認と証跡保存
 
 ## バージョン
 

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,0 +1,25 @@
+# Sponsors
+
+Postal Converter JA keeps Japanese postal-code data easy to integrate, test, and operate in modern software projects.
+
+## Support Options
+
+- GitHub Sponsors: <https://github.com/sponsors/mt4110>
+- Commercial license or implementation support: please open a GitHub Issue first so the scope can be discussed transparently.
+
+## What Sponsorship Supports
+
+- Maintenance of the Rust API, crawler, and SDK sample flows
+- Reproducible onboarding with Nix, Docker, and GitHub Actions
+- MySQL/PostgreSQL integration testing and release verification
+- Documentation, runbooks, and long-term operational hardening
+
+## Commercial Use
+
+Individual, non-profit, and open-source use is available under the MIT License.
+
+For company use, SaaS integration, or redistribution inside a commercial product, this project requests either a commercial license agreement or ongoing sponsorship.
+
+## Note
+
+This project is not officially affiliated with Japan Post unless an explicit partnership is announced.

--- a/docs/ENGLISH_README.md
+++ b/docs/ENGLISH_README.md
@@ -3,6 +3,8 @@
 ![Version](https://img.shields.io/badge/version-0.8.0-blue.svg)
 ![Status](https://img.shields.io/badge/status-beta-orange.svg)
 
+Example Demo: [GitHub Pages](https://mt4110.github.io/postal_converter_ja/) / Support: [SPONSORS.md](../SPONSORS.md) / Plan: [V0_7_TO_V1_EXECUTION_PLAN.md](./V0_7_TO_V1_EXECUTION_PLAN.md)
+
 **Postal Converter JA** is a fully automated system that fetches and updates the latest Japanese postal code data from Japan Post.  
 It consists of a **Rust-based backend (Crawler + API)** and a **Next.js frontend**, providing a high-performance, up-to-date address lookup service.
 
@@ -175,6 +177,12 @@ nix develop --command bash -lc "cd frontend && yarn install && yarn dev"
 
 Demo available at: **http://localhost:3203**
 
+GitHub Pages demo: **https://mt4110.github.io/postal_converter_ja/**
+
+The Pages build uses `NEXT_PUBLIC_DEMO_MODE=true`, so the hosted sample can be explored with bundled demo data even when no public API is available. For live API integration, run the API locally or provide a public `NEXT_PUBLIC_API_URL`.
+
+For the first publish, set `Settings > Pages > Source` to `GitHub Actions`, then run the `Frontend Pages` workflow manually.
+
 ---
 
 ## 🛠 API Documentation
@@ -231,8 +239,8 @@ This model ensures sustainable development and fair support for long-term usage.
 - [x] Lightweight Docker images (multi-stage for API/Crawler)
 - [x] OpenAPI/Swagger documentation
 - [x] Onboarding automation (`scripts/setup_nix_docker.sh`, `scripts/onboard.sh`)
-- [x] Deployment baseline (v0.8): AWS-first with GitHub Actions + Terraform
-- [ ] Kubernetes integration (Helm/Kustomize/ArgoCD)
+- [x] Deployment baseline (v0.8): AWS-first with GitHub Actions + Terraform, plus GCP/Azure target skeletons
+- [x] Kubernetes minimum integration (Helm/Kustomize/ArgoCD)
 
 ### v0.8.x Focus (Deployment baseline)
 
@@ -241,6 +249,13 @@ This model ensures sustainable development and fair support for long-term usage.
 - [x] Offline verification route: `plan` works without AWS secret in skeleton mode
 - [x] Rollback runbook: `destroy` command path with evidence
 - [x] Kubernetes minimum skeleton: Helm + Kustomize + ArgoCD scaffolding
+
+### Human/Auth-Gated Remaining Tasks
+
+- Enable GitHub Pages source as GitHub Actions in repository settings
+- Enable the GitHub Sponsors profile for the `mt4110` account
+- Configure real cloud accounts, OIDC roles, and GitHub Secrets/Variables before Terraform apply/destroy
+- Complete v0.9.2 human QA evidence according to `docs/V0_9_0_ACCEPTANCE.md`
 
 ---
 

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,4 +1,18 @@
+const isGitHubPages = process.env.GITHUB_PAGES === "true";
+const repositoryName =
+  process.env.GITHUB_PAGES_REPOSITORY_NAME ?? "postal_converter_ja";
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = isGitHubPages
+  ? {
+      output: "export",
+      basePath: `/${repositoryName}`,
+      assetPrefix: `/${repositoryName}/`,
+      images: {
+        unoptimized: true,
+      },
+      trailingSlash: true,
+    }
+  : {};
 
 export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev -p 3203",
     "build": "next build",
+    "build:pages": "GITHUB_PAGES=true NEXT_PUBLIC_DEMO_MODE=true next build",
     "start": "next start",
     "lint": "eslint ."
   },

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3,16 +3,17 @@
 @tailwind utilities;
 
 :root {
-  --bg-warm: #f6f2e8;
-  --bg-cool: #d8e8f4;
-  --ink: #1d2b36;
-  --ink-muted: #4d6170;
-  --panel: rgba(255, 255, 255, 0.82);
-  --line: rgba(42, 64, 80, 0.17);
-  --accent: #d97706;
-  --accent-strong: #b45309;
-  --accent-soft: rgba(217, 119, 6, 0.14);
-  --emerald-soft: rgba(15, 118, 110, 0.13);
+  --bg-start: #f7f8fb;
+  --bg-mid: #e9f4f3;
+  --bg-end: #f4f0e8;
+  --ink: #18232d;
+  --ink-muted: #526474;
+  --panel: rgba(255, 255, 255, 0.86);
+  --line: rgba(45, 61, 74, 0.16);
+  --accent: #0f766e;
+  --accent-strong: #155e75;
+  --accent-soft: rgba(15, 118, 110, 0.1);
+  --warm-soft: rgba(214, 128, 48, 0.12);
 }
 
 * {
@@ -22,11 +23,14 @@
 .app-body {
   min-height: 100vh;
   color: var(--ink);
-  font-family: var(--font-text), "Hiragino Sans", "Yu Gothic", Meiryo, sans-serif;
-  background:
-    radial-gradient(1200px 560px at 0% -22%, #fff5ce 0%, transparent 55%),
-    radial-gradient(1200px 560px at 100% -18%, #cdeff0 0%, transparent 58%),
-    linear-gradient(128deg, var(--bg-warm), var(--bg-cool));
+  font-family:
+    var(--font-text), "Hiragino Sans", "Yu Gothic", Meiryo, sans-serif;
+  background: linear-gradient(
+    135deg,
+    var(--bg-start) 0%,
+    var(--bg-mid) 48%,
+    var(--bg-end) 100%
+  );
   position: relative;
 }
 
@@ -35,14 +39,15 @@
   position: fixed;
   inset: 0;
   pointer-events: none;
-  background-image: linear-gradient(
-      to right,
-      rgba(29, 43, 54, 0.04) 1px,
-      transparent 1px
-    ),
+  background-image:
+    linear-gradient(to right, rgba(29, 43, 54, 0.04) 1px, transparent 1px),
     linear-gradient(to bottom, rgba(29, 43, 54, 0.04) 1px, transparent 1px);
   background-size: 28px 28px;
-  mask-image: radial-gradient(circle at center, rgba(0, 0, 0, 0.8), transparent 92%);
+  mask-image: radial-gradient(
+    circle at center,
+    rgba(0, 0, 0, 0.8),
+    transparent 92%
+  );
   z-index: 0;
 }
 
@@ -55,11 +60,13 @@ nav {
 
 @layer components {
   .surface-card {
-    @apply rounded-2xl border p-4 shadow-xl;
+    @apply rounded-lg border p-4 shadow-xl;
     border-color: var(--line);
     background: var(--panel);
-    box-shadow: 0 26px 42px -26px rgba(25, 40, 53, 0.42);
-    backdrop-filter: blur(8px);
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.8) inset,
+      0 22px 38px -30px rgba(24, 35, 45, 0.48);
+    backdrop-filter: blur(12px);
   }
 
   .field-block {
@@ -73,20 +80,20 @@ nav {
   }
 
   .outline-input {
-    @apply h-11 w-full rounded-xl border bg-white px-3 text-sm outline-none transition;
+    @apply h-11 w-full rounded-lg border bg-white px-3 text-sm outline-none transition;
     border-color: var(--line);
     color: var(--ink);
   }
 
   .outline-input:focus {
-    border-color: rgba(217, 119, 6, 0.8);
-    box-shadow: 0 0 0 3px rgba(217, 119, 6, 0.18);
+    border-color: rgba(15, 118, 110, 0.72);
+    box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.14);
   }
 
   .pill-button {
-    @apply inline-flex h-11 items-center justify-center gap-2 rounded-xl px-4 text-sm font-semibold text-white transition;
+    @apply inline-flex h-11 items-center justify-center gap-2 rounded-lg px-4 text-sm font-semibold text-white transition;
     background: linear-gradient(92deg, var(--accent), var(--accent-strong));
-    box-shadow: 0 12px 24px -12px rgba(180, 83, 9, 0.7);
+    box-shadow: 0 12px 24px -14px rgba(15, 94, 117, 0.72);
   }
 
   .pill-button:hover {
@@ -107,14 +114,26 @@ nav {
 
   .ghost-button:hover {
     background: var(--accent-soft);
-    border-color: rgba(217, 119, 6, 0.45);
+    border-color: rgba(15, 118, 110, 0.36);
+  }
+
+  .candidate-list {
+    @apply mt-3 rounded-lg border p-3 text-sm;
+    border-color: var(--line);
+    background:
+      linear-gradient(
+        180deg,
+        rgba(255, 255, 255, 0.78),
+        rgba(255, 255, 255, 0.62)
+      ),
+      var(--warm-soft);
   }
 
   .status-chip {
     @apply rounded-full border px-3 py-1 text-xs font-medium;
     border-color: rgba(15, 118, 110, 0.24);
     color: #0f766e;
-    background: var(--emerald-soft);
+    background: var(--accent-soft);
   }
 }
 

--- a/frontend/src/components/postalShowcase.tsx
+++ b/frontend/src/components/postalShowcase.tsx
@@ -49,7 +49,12 @@ type CallCenterFormState = {
   note: string;
 };
 
-const tabItems: Array<{ id: ActiveTab; label: string; icon: ReactNode; description: string }> = [
+const tabItems: Array<{
+  id: ActiveTab;
+  label: string;
+  icon: ReactNode;
+  description: string;
+}> = [
   {
     id: "ec",
     label: "EC 配送フォーム",
@@ -77,14 +82,72 @@ const panelAnimation = {
   transition: { duration: 0.22, ease: "easeOut" as const },
 };
 
+const demoPostalRecords: PostalCodeRecord[] = [
+  {
+    zip_code: "1000001",
+    prefecture_id: 13,
+    city_id: "13101",
+    prefecture: "東京都",
+    city: "千代田区",
+    town: "千代田",
+  },
+  {
+    zip_code: "1500002",
+    prefecture_id: 13,
+    city_id: "13113",
+    prefecture: "東京都",
+    city: "渋谷区",
+    town: "渋谷",
+  },
+  {
+    zip_code: "1600023",
+    prefecture_id: 13,
+    city_id: "13104",
+    prefecture: "東京都",
+    city: "新宿区",
+    town: "西新宿",
+  },
+  {
+    zip_code: "5300001",
+    prefecture_id: 27,
+    city_id: "27127",
+    prefecture: "大阪府",
+    city: "大阪市北区",
+    town: "梅田",
+  },
+  {
+    zip_code: "0600001",
+    prefecture_id: 1,
+    city_id: "01101",
+    prefecture: "北海道",
+    city: "札幌市中央区",
+    town: "北一条西",
+  },
+];
+
 function normalizeZipInput(value: string): string {
   return value.replace(/\D/g, "").slice(0, 7);
 }
 
-function applyAddressFromRecord<T extends { zipCode: string; prefecture: string; city: string; town: string }>(
-  current: T,
-  record: PostalCodeRecord,
-): T {
+function lookupDemoZip(zipInput: string): PostalCodeRecord[] {
+  const zip = normalizeZipInput(zipInput);
+  return demoPostalRecords.filter((record) => record.zip_code === zip);
+}
+
+function searchDemoAddress(keyword: string, limit: number): PostalCodeRecord[] {
+  const normalizedKeyword = keyword.replace(/\s+/g, "");
+  return demoPostalRecords
+    .filter((record) =>
+      `${record.prefecture}${record.city}${record.town}`.includes(
+        normalizedKeyword,
+      ),
+    )
+    .slice(0, limit);
+}
+
+function applyAddressFromRecord<
+  T extends { zipCode: string; prefecture: string; city: string; town: string },
+>(current: T, record: PostalCodeRecord): T {
   return {
     ...current,
     zipCode: record.zip_code,
@@ -96,6 +159,7 @@ function applyAddressFromRecord<T extends { zipCode: string; prefecture: string;
 
 export default function PostalShowcase() {
   const sdk = useMemo(() => createPostalSdk(), []);
+  const demoMode = process.env.NEXT_PUBLIC_DEMO_MODE === "true";
   const [activeTab, setActiveTab] = useState<ActiveTab>("ec");
 
   const [ecForm, setEcForm] = useState<EcFormState>({
@@ -122,7 +186,9 @@ export default function PostalShowcase() {
     addressDetail: "",
   });
   const [memberKeyword, setMemberKeyword] = useState("");
-  const [memberCandidates, setMemberCandidates] = useState<PostalCodeRecord[]>([]);
+  const [memberCandidates, setMemberCandidates] = useState<PostalCodeRecord[]>(
+    [],
+  );
   const [memberLoading, setMemberLoading] = useState(false);
   const [memberMessage, setMemberMessage] = useState<string>("");
 
@@ -136,7 +202,9 @@ export default function PostalShowcase() {
     town: "",
     note: "",
   });
-  const [callCenterCandidates, setCallCenterCandidates] = useState<PostalCodeRecord[]>([]);
+  const [callCenterCandidates, setCallCenterCandidates] = useState<
+    PostalCodeRecord[]
+  >([]);
   const [callCenterLoading, setCallCenterLoading] = useState(false);
   const [callCenterMessage, setCallCenterMessage] = useState("");
 
@@ -149,7 +217,9 @@ export default function PostalShowcase() {
     setEcLoading(true);
     setEcMessage("");
     try {
-      const rows = await sdk.lookupZip(ecForm.zipCode);
+      const rows = demoMode
+        ? lookupDemoZip(ecForm.zipCode)
+        : await sdk.lookupZip(ecForm.zipCode);
       if (rows.length === 0) {
         setEcCandidates([]);
         setEcMessage("該当する住所が見つかりませんでした");
@@ -158,7 +228,11 @@ export default function PostalShowcase() {
 
       setEcCandidates(rows);
       setEcForm((prev) => applyAddressFromRecord(prev, rows[0]));
-      setEcMessage(`${rows.length}件ヒットしました。候補から選択できます。`);
+      setEcMessage(
+        demoMode
+          ? `${rows.length}件ヒットしました。GitHub Pages用のデモデータです。`
+          : `${rows.length}件ヒットしました。候補から選択できます。`,
+      );
     } catch (error) {
       console.error(error);
       setEcMessage("住所補完に失敗しました。API接続を確認してください。");
@@ -176,7 +250,9 @@ export default function PostalShowcase() {
     setMemberLoading(true);
     setMemberMessage("");
     try {
-      const rows = await sdk.lookupZip(memberForm.zipCode);
+      const rows = demoMode
+        ? lookupDemoZip(memberForm.zipCode)
+        : await sdk.lookupZip(memberForm.zipCode);
       if (rows.length === 0) {
         setMemberCandidates([]);
         setMemberMessage("郵便番号に一致する住所がありません");
@@ -185,7 +261,11 @@ export default function PostalShowcase() {
 
       setMemberCandidates(rows);
       setMemberForm((prev) => applyAddressFromRecord(prev, rows[0]));
-      setMemberMessage(`郵便番号検索で${rows.length}件取得しました`);
+      setMemberMessage(
+        demoMode
+          ? `デモデータから${rows.length}件取得しました`
+          : `郵便番号検索で${rows.length}件取得しました`,
+      );
     } catch (error) {
       console.error(error);
       setMemberMessage("住所補完に失敗しました。API接続を確認してください。");
@@ -204,12 +284,16 @@ export default function PostalShowcase() {
     setMemberLoading(true);
     setMemberMessage("");
     try {
-      const rows = await sdk.searchAddress(keyword, { mode: "partial", limit: 8 });
+      const rows = demoMode
+        ? searchDemoAddress(keyword, 8)
+        : await sdk.searchAddress(keyword, { mode: "partial", limit: 8 });
       setMemberCandidates(rows);
       if (rows.length === 0) {
         setMemberMessage("該当候補はありませんでした");
       } else {
-        setMemberMessage(`${rows.length}件ヒットしました。候補を選択してください。`);
+        setMemberMessage(
+          `${rows.length}件ヒットしました。候補を選択してください。`,
+        );
       }
     } catch (error) {
       console.error(error);
@@ -228,13 +312,19 @@ export default function PostalShowcase() {
     setCallCenterLoading(true);
     setCallCenterMessage("");
     try {
-      const rows = await sdk.lookupZip(callCenterForm.zipCode);
+      const rows = demoMode
+        ? lookupDemoZip(callCenterForm.zipCode)
+        : await sdk.lookupZip(callCenterForm.zipCode);
       setCallCenterCandidates(rows);
       if (rows.length === 0) {
         setCallCenterMessage("候補が見つかりませんでした");
       } else {
         setCallCenterForm((prev) => applyAddressFromRecord(prev, rows[0]));
-        setCallCenterMessage(`${rows.length}件ヒット。候補を選択してください。`);
+        setCallCenterMessage(
+          demoMode
+            ? `${rows.length}件ヒット。デモデータから候補を選択できます。`
+            : `${rows.length}件ヒット。候補を選択してください。`,
+        );
       }
     } catch (error) {
       console.error(error);
@@ -254,12 +344,16 @@ export default function PostalShowcase() {
     setCallCenterLoading(true);
     setCallCenterMessage("");
     try {
-      const rows = await sdk.searchAddress(keyword, { mode: "partial", limit: 10 });
+      const rows = demoMode
+        ? searchDemoAddress(keyword, 10)
+        : await sdk.searchAddress(keyword, { mode: "partial", limit: 10 });
       setCallCenterCandidates(rows);
       if (rows.length === 0) {
         setCallCenterMessage("候補がありませんでした");
       } else {
-        setCallCenterMessage(`${rows.length}件ヒット。通話中に候補を選択してください。`);
+        setCallCenterMessage(
+          `${rows.length}件ヒット。通話中に候補を選択してください。`,
+        );
       }
     } catch (error) {
       console.error(error);
@@ -277,11 +371,18 @@ export default function PostalShowcase() {
         transition={{ duration: 0.35, ease: "easeOut" }}
         className="surface-card relative overflow-hidden p-6 md:p-8"
       >
-        <div className="pointer-events-none absolute -right-12 -top-12 h-40 w-40 rounded-full bg-[rgba(15,118,110,0.18)] blur-2xl" />
-        <div className="pointer-events-none absolute -bottom-16 left-8 h-44 w-44 rounded-full bg-[rgba(217,119,6,0.16)] blur-2xl" />
         <div className="relative z-10">
           <p className="status-chip inline-flex items-center gap-2">
-            <Sparkles className="h-4 w-4" />
+            <motion.span
+              animate={{ rotate: [0, 8, -4, 0] }}
+              transition={{
+                duration: 2.8,
+                repeat: Infinity,
+                ease: "easeInOut",
+              }}
+            >
+              <Sparkles className="h-4 w-4" />
+            </motion.span>
             導入SDKサンプル
           </p>
           <h1 className="mt-4 text-3xl font-bold tracking-tight md:text-4xl">
@@ -291,8 +392,16 @@ export default function PostalShowcase() {
             ECフォーム、会員登録、コールセンター入力支援の3パターンを同じSDKで実装。郵便番号厳密検索と住所キーワード検索を組み合わせ、
             入力工数と誤記を同時に削減できます。
           </p>
-          <div className="mt-4 text-xs text-[color:var(--ink-muted)] md:text-sm">
-            API Base URL: <code className="rounded bg-black/5 px-2 py-1">{process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3202"}</code>
+          <div className="mt-4 flex flex-wrap items-center gap-2 text-xs text-[color:var(--ink-muted)] md:text-sm">
+            <span className="rounded-md bg-black/5 px-2 py-1">
+              {demoMode ? "GitHub Pages demo data" : "Live API"}
+            </span>
+            <span>
+              API Base URL:{" "}
+              <code className="rounded-md bg-black/5 px-2 py-1">
+                {process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3202"}
+              </code>
+            </span>
           </div>
         </div>
       </motion.section>
@@ -306,25 +415,42 @@ export default function PostalShowcase() {
         {tabItems.map((tab) => {
           const active = activeTab === tab.id;
           return (
-            <button
+            <motion.button
               key={tab.id}
               type="button"
               onClick={() => setActiveTab(tab.id)}
-              className={`surface-card text-left transition-all ${active ? "ring-2 ring-[color:var(--accent)]" : "hover:-translate-y-0.5"}`}
+              whileHover={{ y: -2 }}
+              whileTap={{ scale: 0.99 }}
+              className={`surface-card text-left transition-all ${active ? "ring-2 ring-[color:var(--accent)]" : ""}`}
             >
               <div className="flex items-center gap-2 text-sm font-semibold">
-                {tab.icon}
+                <motion.span
+                  animate={
+                    active
+                      ? { rotate: 8, scale: 1.05 }
+                      : { rotate: 0, scale: 1 }
+                  }
+                  transition={{ duration: 0.2, ease: "easeOut" }}
+                >
+                  {tab.icon}
+                </motion.span>
                 {tab.label}
               </div>
-              <p className="mt-2 text-xs text-[color:var(--ink-muted)] md:text-sm">{tab.description}</p>
-            </button>
+              <p className="mt-2 text-xs text-[color:var(--ink-muted)] md:text-sm">
+                {tab.description}
+              </p>
+            </motion.button>
           );
         })}
       </motion.nav>
 
       <AnimatePresence mode="wait">
         {activeTab === "ec" ? (
-          <motion.section key="ec-panel" {...panelAnimation} className="mt-6 surface-card p-6 md:p-8">
+          <motion.section
+            key="ec-panel"
+            {...panelAnimation}
+            className="mt-6 surface-card p-6 md:p-8"
+          >
             <div className="mb-6 flex items-center gap-2 text-lg font-semibold md:text-xl">
               <Truck className="h-5 w-5" />
               EC 配送先自動補完サンプル
@@ -345,8 +471,22 @@ export default function PostalShowcase() {
                       }))
                     }
                   />
-                  <button type="button" className="pill-button" onClick={handleEcZipLookup} disabled={ecLoading}>
-                    <Search className="h-4 w-4" />
+                  <button
+                    type="button"
+                    className="pill-button"
+                    onClick={handleEcZipLookup}
+                    disabled={ecLoading}
+                  >
+                    <motion.span
+                      animate={ecLoading ? { rotate: 360 } : { rotate: 0 }}
+                      transition={
+                        ecLoading
+                          ? { repeat: Infinity, duration: 0.9, ease: "linear" }
+                          : { duration: 0.16 }
+                      }
+                    >
+                      <Search className="h-4 w-4" />
+                    </motion.span>
                     {ecLoading ? "検索中..." : "住所を補完"}
                   </button>
                 </div>
@@ -357,7 +497,12 @@ export default function PostalShowcase() {
                 <input
                   className="outline-input"
                   value={ecForm.customerName}
-                  onChange={(event) => setEcForm((prev) => ({ ...prev, customerName: event.target.value }))}
+                  onChange={(event) =>
+                    setEcForm((prev) => ({
+                      ...prev,
+                      customerName: event.target.value,
+                    }))
+                  }
                   placeholder="山田 太郎"
                 />
               </label>
@@ -367,7 +512,12 @@ export default function PostalShowcase() {
                 <input
                   className="outline-input"
                   value={ecForm.phone}
-                  onChange={(event) => setEcForm((prev) => ({ ...prev, phone: event.target.value }))}
+                  onChange={(event) =>
+                    setEcForm((prev) => ({
+                      ...prev,
+                      phone: event.target.value,
+                    }))
+                  }
                   placeholder="09012345678"
                 />
               </label>
@@ -377,7 +527,12 @@ export default function PostalShowcase() {
                 <input
                   className="outline-input"
                   value={ecForm.prefecture}
-                  onChange={(event) => setEcForm((prev) => ({ ...prev, prefecture: event.target.value }))}
+                  onChange={(event) =>
+                    setEcForm((prev) => ({
+                      ...prev,
+                      prefecture: event.target.value,
+                    }))
+                  }
                   placeholder="東京都"
                 />
               </label>
@@ -387,7 +542,9 @@ export default function PostalShowcase() {
                 <input
                   className="outline-input"
                   value={ecForm.city}
-                  onChange={(event) => setEcForm((prev) => ({ ...prev, city: event.target.value }))}
+                  onChange={(event) =>
+                    setEcForm((prev) => ({ ...prev, city: event.target.value }))
+                  }
                   placeholder="千代田区"
                 />
               </label>
@@ -397,7 +554,9 @@ export default function PostalShowcase() {
                 <input
                   className="outline-input"
                   value={ecForm.town}
-                  onChange={(event) => setEcForm((prev) => ({ ...prev, town: event.target.value }))}
+                  onChange={(event) =>
+                    setEcForm((prev) => ({ ...prev, town: event.target.value }))
+                  }
                   placeholder="千代田"
                 />
               </label>
@@ -407,7 +566,12 @@ export default function PostalShowcase() {
                 <input
                   className="outline-input"
                   value={ecForm.street}
-                  onChange={(event) => setEcForm((prev) => ({ ...prev, street: event.target.value }))}
+                  onChange={(event) =>
+                    setEcForm((prev) => ({
+                      ...prev,
+                      street: event.target.value,
+                    }))
+                  }
                   placeholder="1-1"
                 />
               </label>
@@ -417,36 +581,57 @@ export default function PostalShowcase() {
                 <input
                   className="outline-input"
                   value={ecForm.building}
-                  onChange={(event) => setEcForm((prev) => ({ ...prev, building: event.target.value }))}
+                  onChange={(event) =>
+                    setEcForm((prev) => ({
+                      ...prev,
+                      building: event.target.value,
+                    }))
+                  }
                   placeholder="サンプルビル 1201"
                 />
               </label>
             </div>
 
-            <div className="mt-4 min-h-6 text-sm text-[color:var(--ink-muted)]">{ecMessage}</div>
+            <div className="mt-4 min-h-6 text-sm text-[color:var(--ink-muted)]">
+              {ecMessage}
+            </div>
             {ecCandidates.length > 1 ? (
-              <div className="mt-3 rounded-xl border border-[color:var(--line)] bg-white/80 p-3 text-sm">
+              <motion.div
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="candidate-list"
+              >
                 <div className="mb-2 font-medium">候補を選択</div>
                 <div className="grid gap-2">
                   {ecCandidates.map((candidate) => (
-                    <button
+                    <motion.button
                       key={`${candidate.zip_code}-${candidate.city_id}-${candidate.town}`}
                       type="button"
                       className="ghost-button justify-start"
-                      onClick={() => setEcForm((prev) => applyAddressFromRecord(prev, candidate))}
+                      whileHover={{ x: 2 }}
+                      whileTap={{ scale: 0.99 }}
+                      onClick={() =>
+                        setEcForm((prev) =>
+                          applyAddressFromRecord(prev, candidate),
+                        )
+                      }
                     >
                       <MapPinned className="h-4 w-4" />
                       {candidate.prefecture}
                       {candidate.city}
                       {candidate.town} ({formatZip(candidate.zip_code)})
-                    </button>
+                    </motion.button>
                   ))}
                 </div>
-              </div>
+              </motion.div>
             ) : null}
           </motion.section>
         ) : activeTab === "member" ? (
-          <motion.section key="member-panel" {...panelAnimation} className="mt-6 surface-card p-6 md:p-8">
+          <motion.section
+            key="member-panel"
+            {...panelAnimation}
+            className="mt-6 surface-card p-6 md:p-8"
+          >
             <div className="mb-6 flex items-center gap-2 text-lg font-semibold md:text-xl">
               <IdCard className="h-5 w-5" />
               会員登録フォーム補完サンプル
@@ -458,7 +643,12 @@ export default function PostalShowcase() {
                 <input
                   className="outline-input"
                   value={memberForm.fullName}
-                  onChange={(event) => setMemberForm((prev) => ({ ...prev, fullName: event.target.value }))}
+                  onChange={(event) =>
+                    setMemberForm((prev) => ({
+                      ...prev,
+                      fullName: event.target.value,
+                    }))
+                  }
                   placeholder="郵便 花子"
                 />
               </label>
@@ -468,7 +658,12 @@ export default function PostalShowcase() {
                 <input
                   className="outline-input"
                   value={memberForm.email}
-                  onChange={(event) => setMemberForm((prev) => ({ ...prev, email: event.target.value }))}
+                  onChange={(event) =>
+                    setMemberForm((prev) => ({
+                      ...prev,
+                      email: event.target.value,
+                    }))
+                  }
                   placeholder="hanako@example.com"
                 />
               </label>
@@ -487,9 +682,23 @@ export default function PostalShowcase() {
                       }))
                     }
                   />
-                  <button type="button" className="pill-button" onClick={handleMemberZipLookup} disabled={memberLoading}>
-                    <Search className="h-4 w-4" />
-                    郵便番号で補完
+                  <button
+                    type="button"
+                    className="pill-button"
+                    onClick={handleMemberZipLookup}
+                    disabled={memberLoading}
+                  >
+                    <motion.span
+                      animate={memberLoading ? { rotate: 360 } : { rotate: 0 }}
+                      transition={
+                        memberLoading
+                          ? { repeat: Infinity, duration: 0.9, ease: "linear" }
+                          : { duration: 0.16 }
+                      }
+                    >
+                      <Search className="h-4 w-4" />
+                    </motion.span>
+                    {memberLoading ? "検索中..." : "郵便番号で補完"}
                   </button>
                 </div>
               </label>
@@ -509,8 +718,17 @@ export default function PostalShowcase() {
                     onClick={handleMemberKeywordSearch}
                     disabled={memberLoading}
                   >
-                    <Building2 className="h-4 w-4" />
-                    キーワード検索
+                    <motion.span
+                      animate={memberLoading ? { rotate: 360 } : { rotate: 0 }}
+                      transition={
+                        memberLoading
+                          ? { repeat: Infinity, duration: 0.9, ease: "linear" }
+                          : { duration: 0.16 }
+                      }
+                    >
+                      <Building2 className="h-4 w-4" />
+                    </motion.span>
+                    {memberLoading ? "検索中..." : "キーワード検索"}
                   </button>
                 </div>
               </label>
@@ -520,7 +738,12 @@ export default function PostalShowcase() {
                 <input
                   className="outline-input"
                   value={memberForm.prefecture}
-                  onChange={(event) => setMemberForm((prev) => ({ ...prev, prefecture: event.target.value }))}
+                  onChange={(event) =>
+                    setMemberForm((prev) => ({
+                      ...prev,
+                      prefecture: event.target.value,
+                    }))
+                  }
                 />
               </label>
 
@@ -529,7 +752,12 @@ export default function PostalShowcase() {
                 <input
                   className="outline-input"
                   value={memberForm.city}
-                  onChange={(event) => setMemberForm((prev) => ({ ...prev, city: event.target.value }))}
+                  onChange={(event) =>
+                    setMemberForm((prev) => ({
+                      ...prev,
+                      city: event.target.value,
+                    }))
+                  }
                 />
               </label>
 
@@ -538,7 +766,12 @@ export default function PostalShowcase() {
                 <input
                   className="outline-input"
                   value={memberForm.town}
-                  onChange={(event) => setMemberForm((prev) => ({ ...prev, town: event.target.value }))}
+                  onChange={(event) =>
+                    setMemberForm((prev) => ({
+                      ...prev,
+                      town: event.target.value,
+                    }))
+                  }
                 />
               </label>
 
@@ -547,36 +780,57 @@ export default function PostalShowcase() {
                 <input
                   className="outline-input"
                   value={memberForm.addressDetail}
-                  onChange={(event) => setMemberForm((prev) => ({ ...prev, addressDetail: event.target.value }))}
+                  onChange={(event) =>
+                    setMemberForm((prev) => ({
+                      ...prev,
+                      addressDetail: event.target.value,
+                    }))
+                  }
                   placeholder="2-8-1"
                 />
               </label>
             </div>
 
-            <div className="mt-4 min-h-6 text-sm text-[color:var(--ink-muted)]">{memberMessage}</div>
+            <div className="mt-4 min-h-6 text-sm text-[color:var(--ink-muted)]">
+              {memberMessage}
+            </div>
             {memberCandidates.length > 0 ? (
-              <div className="mt-3 rounded-xl border border-[color:var(--line)] bg-white/80 p-3 text-sm">
+              <motion.div
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="candidate-list"
+              >
                 <div className="mb-2 font-medium">検索候補</div>
                 <div className="grid gap-2">
                   {memberCandidates.map((candidate) => (
-                    <button
+                    <motion.button
                       key={`member-${candidate.zip_code}-${candidate.city_id}-${candidate.town}`}
                       type="button"
                       className="ghost-button justify-start"
-                      onClick={() => setMemberForm((prev) => applyAddressFromRecord(prev, candidate))}
+                      whileHover={{ x: 2 }}
+                      whileTap={{ scale: 0.99 }}
+                      onClick={() =>
+                        setMemberForm((prev) =>
+                          applyAddressFromRecord(prev, candidate),
+                        )
+                      }
                     >
                       <MapPinned className="h-4 w-4" />
                       {candidate.prefecture}
                       {candidate.city}
                       {candidate.town} ({formatZip(candidate.zip_code)})
-                    </button>
+                    </motion.button>
                   ))}
                 </div>
-              </div>
+              </motion.div>
             ) : null}
           </motion.section>
         ) : (
-          <motion.section key="callcenter-panel" {...panelAnimation} className="mt-6 surface-card p-6 md:p-8">
+          <motion.section
+            key="callcenter-panel"
+            {...panelAnimation}
+            className="mt-6 surface-card p-6 md:p-8"
+          >
             <div className="mb-6 flex items-center gap-2 text-lg font-semibold md:text-xl">
               <Headset className="h-5 w-5" />
               コールセンター入力支援サンプル
@@ -588,7 +842,12 @@ export default function PostalShowcase() {
                 <input
                   className="outline-input"
                   value={callCenterForm.customerId}
-                  onChange={(event) => setCallCenterForm((prev) => ({ ...prev, customerId: event.target.value }))}
+                  onChange={(event) =>
+                    setCallCenterForm((prev) => ({
+                      ...prev,
+                      customerId: event.target.value,
+                    }))
+                  }
                   placeholder="CUST-2026-0001"
                 />
               </label>
@@ -600,7 +859,12 @@ export default function PostalShowcase() {
                   <input
                     className="outline-input"
                     value={callCenterForm.phone}
-                    onChange={(event) => setCallCenterForm((prev) => ({ ...prev, phone: event.target.value }))}
+                    onChange={(event) =>
+                      setCallCenterForm((prev) => ({
+                        ...prev,
+                        phone: event.target.value,
+                      }))
+                    }
                     placeholder="0312345678"
                   />
                 </div>
@@ -626,8 +890,19 @@ export default function PostalShowcase() {
                     onClick={handleCallCenterZipLookup}
                     disabled={callCenterLoading}
                   >
-                    <Search className="h-4 w-4" />
-                    郵便番号検索
+                    <motion.span
+                      animate={
+                        callCenterLoading ? { rotate: 360 } : { rotate: 0 }
+                      }
+                      transition={
+                        callCenterLoading
+                          ? { repeat: Infinity, duration: 0.9, ease: "linear" }
+                          : { duration: 0.16 }
+                      }
+                    >
+                      <Search className="h-4 w-4" />
+                    </motion.span>
+                    {callCenterLoading ? "検索中..." : "郵便番号検索"}
                   </button>
                 </div>
               </label>
@@ -638,7 +913,12 @@ export default function PostalShowcase() {
                   <input
                     className="outline-input"
                     value={callCenterForm.keyword}
-                    onChange={(event) => setCallCenterForm((prev) => ({ ...prev, keyword: event.target.value }))}
+                    onChange={(event) =>
+                      setCallCenterForm((prev) => ({
+                        ...prev,
+                        keyword: event.target.value,
+                      }))
+                    }
                     placeholder="梅田 / 渋谷 など"
                   />
                   <button
@@ -647,8 +927,19 @@ export default function PostalShowcase() {
                     onClick={handleCallCenterKeywordSearch}
                     disabled={callCenterLoading}
                   >
-                    <Building2 className="h-4 w-4" />
-                    候補検索
+                    <motion.span
+                      animate={
+                        callCenterLoading ? { rotate: 360 } : { rotate: 0 }
+                      }
+                      transition={
+                        callCenterLoading
+                          ? { repeat: Infinity, duration: 0.9, ease: "linear" }
+                          : { duration: 0.16 }
+                      }
+                    >
+                      <Building2 className="h-4 w-4" />
+                    </motion.span>
+                    {callCenterLoading ? "検索中..." : "候補検索"}
                   </button>
                 </div>
               </label>
@@ -658,7 +949,12 @@ export default function PostalShowcase() {
                 <input
                   className="outline-input"
                   value={callCenterForm.prefecture}
-                  onChange={(event) => setCallCenterForm((prev) => ({ ...prev, prefecture: event.target.value }))}
+                  onChange={(event) =>
+                    setCallCenterForm((prev) => ({
+                      ...prev,
+                      prefecture: event.target.value,
+                    }))
+                  }
                 />
               </label>
 
@@ -667,7 +963,12 @@ export default function PostalShowcase() {
                 <input
                   className="outline-input"
                   value={callCenterForm.city}
-                  onChange={(event) => setCallCenterForm((prev) => ({ ...prev, city: event.target.value }))}
+                  onChange={(event) =>
+                    setCallCenterForm((prev) => ({
+                      ...prev,
+                      city: event.target.value,
+                    }))
+                  }
                 />
               </label>
 
@@ -676,7 +977,12 @@ export default function PostalShowcase() {
                 <input
                   className="outline-input"
                   value={callCenterForm.town}
-                  onChange={(event) => setCallCenterForm((prev) => ({ ...prev, town: event.target.value }))}
+                  onChange={(event) =>
+                    setCallCenterForm((prev) => ({
+                      ...prev,
+                      town: event.target.value,
+                    }))
+                  }
                 />
               </label>
 
@@ -685,34 +991,49 @@ export default function PostalShowcase() {
                 <input
                   className="outline-input"
                   value={callCenterForm.note}
-                  onChange={(event) => setCallCenterForm((prev) => ({ ...prev, note: event.target.value }))}
+                  onChange={(event) =>
+                    setCallCenterForm((prev) => ({
+                      ...prev,
+                      note: event.target.value,
+                    }))
+                  }
                   placeholder="再配達希望時間など"
                 />
               </label>
             </div>
 
-            <div className="mt-4 min-h-6 text-sm text-[color:var(--ink-muted)]">{callCenterMessage}</div>
+            <div className="mt-4 min-h-6 text-sm text-[color:var(--ink-muted)]">
+              {callCenterMessage}
+            </div>
             {callCenterCandidates.length > 0 ? (
-              <div className="mt-3 rounded-xl border border-[color:var(--line)] bg-white/80 p-3 text-sm">
+              <motion.div
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="candidate-list"
+              >
                 <div className="mb-2 font-medium">通話中候補</div>
                 <div className="grid gap-2">
                   {callCenterCandidates.map((candidate) => (
-                    <button
+                    <motion.button
                       key={`cc-${candidate.zip_code}-${candidate.city_id}-${candidate.town}`}
                       type="button"
                       className="ghost-button justify-start"
+                      whileHover={{ x: 2 }}
+                      whileTap={{ scale: 0.99 }}
                       onClick={() =>
-                        setCallCenterForm((prev) => applyAddressFromRecord(prev, candidate))
+                        setCallCenterForm((prev) =>
+                          applyAddressFromRecord(prev, candidate),
+                        )
                       }
                     >
                       <MapPinned className="h-4 w-4" />
                       {candidate.prefecture}
                       {candidate.city}
                       {candidate.town} ({formatZip(candidate.zip_code)})
-                    </button>
+                    </motion.button>
                   ))}
                 </div>
-              </div>
+              </motion.div>
             ) : null}
           </motion.section>
         )}
@@ -726,10 +1047,11 @@ export default function PostalShowcase() {
       >
         <h2 className="text-lg font-semibold">導入SDKの最小コード</h2>
         <p className="mt-2 text-sm text-[color:var(--ink-muted)]">
-          フォーム側はSDKの `lookupZip` / `searchAddress` を呼ぶだけで導入できます。
+          フォーム側はSDKの `lookupZip` / `searchAddress`
+          を呼ぶだけで導入できます。
         </p>
         <pre className="mt-4 overflow-x-auto rounded-xl border border-[color:var(--line)] bg-[#101820] p-4 text-xs leading-6 text-[#d7e4ef] md:text-sm">
-{`import { createPostalSdk } from "@/lib/postal-sdk";
+          {`import { createPostalSdk } from "@/lib/postal-sdk";
 
 const sdk = createPostalSdk({ baseUrl: process.env.NEXT_PUBLIC_API_URL });
 


### PR DESCRIPTION
## Summary
- Add a GitHub Pages workflow for the frontend static export
- Add Pages demo mode with bundled sample postal records so the hosted example works without a public API
- Refresh the example UI with quieter Apple-like surfaces and small motion feedback
- Add SPONSORS.md, .github/FUNDING.yml, README demo/support links, and .codex/ ignore

## Notes
- First Pages publish still requires a repository admin/maintainer to set Settings > Pages > Source to GitHub Actions.
- GitHub Sponsors also requires the mt4110 account to enable a Sponsors profile.

## Validation
- yarn install --frozen-lockfile
- yarn lint
- yarn build
- yarn build:pages
- static export served locally under /postal_converter_ja/ and screenshot-checked on desktop/mobile